### PR TITLE
chore: remote config client

### DIFF
--- a/Sources/AmplitudeCore/Remote Config/RemoteConfigClient.swift
+++ b/Sources/AmplitudeCore/Remote Config/RemoteConfigClient.swift
@@ -1,0 +1,378 @@
+//
+//  RemoteConfigClient.swift
+//  Amplitude-Swift
+//
+//  Created by Chris Leonavicius on 1/14/25.
+//
+
+import Foundation
+
+public actor RemoteConfigClient: NSObject {
+
+    public enum DeliveryMode: Sendable {
+        // Recieve all config updates as they occur
+        case all
+
+        // Waits for a remote response until the given timeout, then return a cached copy, if available.
+        case waitForRemote(timeout: TimeInterval = 3)
+    }
+
+    public enum Source: Sendable {
+        case cache
+        case remote
+    }
+
+    public enum RemoteConfigError: Error {
+        case notInCache
+        case invalidServerURL
+        case badResponse
+    }
+
+    private struct Config {
+        static let usServerURL = "https://sr-client-cfg.amplitude.com/config"
+        static let euServerURL = "https://sr-client-cfg.eu.amplitude.com/config"
+        static let maxRetries = 3
+        static let minTimeBetweenFetches: TimeInterval = 5 * 60
+        static let fetchedKeys = [
+            "sessionReplay.sr_ios_privacy_config",
+            "sessionReplay.sr_ios_sampling_config",
+            "analyticsSDK.browserSDK",
+        ]
+    }
+
+    private class CallbackInfo {
+        let id: UUID
+        let key: String?
+        let deliveryMode: DeliveryMode
+        let callback: RemoteConfigCallback
+
+        var lastCallbackTime: Date?
+
+        init(id: UUID,
+             key: String?,
+             deliveryMode: DeliveryMode,
+             callback: @escaping RemoteConfigCallback) {
+            self.id = id
+            self.key = key
+            self.deliveryMode = deliveryMode
+            self.callback = callback
+        }
+    }
+
+    struct RemoteConfigInfo: Sendable {
+        let config: RemoteConfig
+        let lastFetch: Date
+    }
+
+    protocol Storage: Sendable {
+        func fetchConfig() async throws -> RemoteConfigInfo?
+        func setConfig(_ config: RemoteConfigInfo?) async throws
+    }
+
+    public typealias RemoteConfig = [String: Sendable]
+    public typealias RemoteConfigCallback = @Sendable (RemoteConfig?, Source, Date?) -> Void
+
+    private let apiKey: String
+    private let serverUrl: String
+    private let urlSession: URLSession
+    private let queue = DispatchQueue(label: "com.amplitude.sessionreplay.remoteconfig", target: .global())
+    private let jsonDecoder = JSONDecoder()
+    private let storage: Storage
+    private let logger: Logger
+
+    private var fetchLocalTask: Task<RemoteConfigInfo, Error>
+    private var fetchRemoteTask: Task<RemoteConfigInfo, Error>
+    private var callbacks: [CallbackInfo] = []
+
+    public init(apiKey: String,
+                serverZone: ServerZone,
+                instanceName: String? = nil,
+                logger: Logger) {
+        let serverURL: String
+        switch serverZone {
+        case .US:
+            serverURL = Config.usServerURL
+        case .EU:
+            serverURL = Config.euServerURL
+        }
+        self.init(apiKey: apiKey,
+                  serverUrl: serverURL,
+                  logger: logger,
+                  storage: RemoteConfigUserDefaultsStorage(instanceName: instanceName))
+    }
+
+    init(apiKey: String,
+         serverUrl: String,
+         logger: Logger = ConsoleLogger(),
+         storage: Storage = RemoteConfigUserDefaultsStorage(),
+         urlSessionConfiguration: URLSessionConfiguration = .ephemeral) {
+        self.apiKey = apiKey
+        self.serverUrl = serverUrl
+        self.logger = logger
+        self.storage = storage
+        self.urlSession = URLSession(configuration: urlSessionConfiguration)
+
+        fetchLocalTask = Task {
+            guard let config = try await storage.fetchConfig() else {
+                throw RemoteConfigError.notInCache
+            }
+            return config
+        }
+
+        var futureSelf: RemoteConfigClient? = nil
+        fetchRemoteTask = Task {
+            guard let futureSelf else {
+                throw RemoteConfigError.badResponse
+            }
+            let configInfo = try await futureSelf.fetch()
+            try? await storage.setConfig(configInfo)
+            return configInfo
+        }
+
+        super.init()
+
+        futureSelf = self
+    }
+
+    /**
+     Subscribe for updates to remote config. Callback is guaranteed to be called at least once, whether we are able to fetch a config or not.
+
+     - Parameters:
+        - key: A String containing a series of period delimited keys to filter the returned config. Ie, {a: {b: {c: ...}}} would return {b: {c: ...} for "a" or {c: ...} for "a.b"
+        - deliveryMode: How the initial callback is sent. See ``RemoteConfigClient/DeliveryMode`` for more details.
+        - callback: A block that will
+     - Returns: A token that can be used to unsubscribe from updates
+     */
+    @discardableResult
+    public nonisolated func subscribe(key: String? = nil,
+                                      deliveryMode: DeliveryMode = .all,
+                                      callback: @escaping @Sendable RemoteConfigCallback) -> Any {
+        let id = UUID()
+        Task {
+            await _subscribe(id: id, key: key, deliveryMode: deliveryMode, callback: callback)
+        }
+        return id
+    }
+
+    private func _subscribe(id: UUID,
+                            key: String?,
+                            deliveryMode: DeliveryMode,
+                            callback: @escaping @Sendable RemoteConfigCallback) {
+        Task {
+            let callbackInfo = CallbackInfo(id: id, key: key, deliveryMode: deliveryMode, callback: callback)
+            callbacks.append(callbackInfo)
+
+            switch callbackInfo.deliveryMode {
+            case .all:
+                Task {
+                    await withThrowingTaskGroup(of: (configInfo: RemoteConfigInfo, source: Source).self) { [fetchLocalTask, fetchRemoteTask] taskGroup in
+                        // send remote first, if it's already complete we can skip the cached response
+                        taskGroup.addTask {
+                            return (try await fetchRemoteTask.value, .remote)
+                        }
+                        taskGroup.addTask {
+                            return (try await fetchLocalTask.value, .cache)
+                        }
+                        var didSendCallback = false
+                        while let taskGroupResult = await taskGroup.nextResult() {
+                            if case .success(let result) = taskGroupResult {
+                                didSendCallback = true
+
+                                sendCallback(callbackInfo, configInfo: result.configInfo, source: result.source)
+
+                                // no need to send local callbacks if we already have remote
+                                if case .remote = result.source {
+                                    break
+                                }
+                            }
+                        }
+
+                        guard !didSendCallback else {
+                            return
+                        }
+
+                        sendCallback(callbackInfo, configInfo: nil, source: .remote)
+                    }
+                }
+            case .waitForRemote(timeout: let timeout):
+                let fetchTask = Task {
+                    let config = try await fetchRemoteTask.value
+                    try Task.checkCancellation()
+                    return config
+                }
+
+                let timeoutTask = Task {
+                    try await Task.sleep(nanoseconds: UInt64(timeout * TimeInterval(NSEC_PER_SEC)))
+                    try Task.checkCancellation()
+                    fetchTask.cancel()
+                }
+
+                do {
+                    let remoteConfig = try await fetchTask.value
+                    timeoutTask.cancel()
+                    sendCallback(callbackInfo, configInfo: remoteConfig, source: .remote)
+                } catch {
+                    // timeout or remote fetch error, try storage
+                    if let localConfig = try? await fetchLocalTask.value {
+                        sendCallback(callbackInfo, configInfo: localConfig, source: .cache)
+                    } else {
+                        sendCallback(callbackInfo, configInfo: nil, source: .remote)
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     Removes a callback from receiving future updates.
+
+     - Parameters:
+     - token: the result of a subscribe call to unregister for future updates.
+     */
+    public nonisolated func unsubscribe(_ token: Any) {
+        guard let uuid = token as? UUID else {
+            return
+        }
+        Task {
+            await _unsubscribe(id: uuid)
+        }
+    }
+
+    private func _unsubscribe(id: UUID) {
+        callbacks.removeAll { $0.id == id }
+    }
+
+    /**
+     Requests that the Remote config client updates its configs.
+     */
+    public nonisolated func updateConfigs() {
+        Task {
+            try await _updateConfigs()
+        }
+    }
+
+    private func _updateConfigs() async throws {
+        // wait for any existing fetches to complete
+        switch await fetchRemoteTask.result {
+        case .success(let configInfo):
+            guard configInfo.lastFetch.timeIntervalSinceNow < -Config.minTimeBetweenFetches else {
+                logger.debug(message: "[RemoteConfigClient] Skipping updateConfigs: Too recent")
+                return
+            }
+        case .failure:
+            break
+        }
+
+        fetchRemoteTask = Task {
+            let configInfo = try await fetch()
+            try? await storage.setConfig(configInfo)
+            return configInfo
+        }
+
+        if let updatedRemoteConfig = try? await fetchRemoteTask.value {
+            for callback in callbacks {
+                switch callback.deliveryMode {
+                case .all:
+                    break
+                case .waitForRemote:
+                    // Wait until the initial callback from registerForUpdates is fired
+                    guard callback.lastCallbackTime == nil else {
+                        continue
+                    }
+                }
+
+                sendCallback(callback, configInfo: updatedRemoteConfig, source: .remote)
+            }
+        }
+    }
+
+    private func sendCallback(_ callbackInfo: CallbackInfo, configInfo: RemoteConfigInfo?, source: Source) {
+        callbackInfo.lastCallbackTime = Date()
+
+        var filteredConfig: RemoteConfig?
+        if let key = callbackInfo.key {
+            filteredConfig = key.split(separator: ".").reduce(configInfo?.config) { config, currentKey in
+                return config?[String(currentKey)] as? RemoteConfig
+            }
+        } else {
+            filteredConfig = configInfo?.config
+        }
+
+        callbackInfo.callback(filteredConfig, source, configInfo?.lastFetch)
+    }
+
+    // MARK: - Fetch
+
+    private func fetch(request: URLRequest? = nil, retries: Int = 3) async throws -> RemoteConfigInfo {
+        let currentRequest = try request ?? makeRequest()
+        let (data, response) = try await urlSession.data(for: currentRequest)
+
+        if let httpResponse = response as? HTTPURLResponse,
+           httpResponse.statusCode == 200,
+           let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Sendable],
+           let config = json["configs"] as? [String: Sendable] {
+            return RemoteConfigInfo(config: config, lastFetch: Date())
+        } else if retries > 0 {
+            return try await fetch(request: currentRequest, retries: retries - 1)
+        } else {
+            throw RemoteConfigError.badResponse
+        }
+    }
+
+    private func makeRequest() throws -> URLRequest {
+        guard var urlComponents = URLComponents(string: serverUrl) else {
+            throw RemoteConfigError.invalidServerURL
+        }
+
+        var queryItems: [URLQueryItem] = []
+        queryItems.append(URLQueryItem(name: "api_key", value: apiKey))
+
+        for configKey in Config.fetchedKeys {
+            queryItems.append(URLQueryItem(name: "config_keys", value: configKey))
+        }
+
+        urlComponents.queryItems = queryItems
+
+        guard let url = urlComponents.url else {
+            throw RemoteConfigError.invalidServerURL
+        }
+
+        return HttpUtil.makeJsonRequest(url: url)
+    }
+}
+
+final class RemoteConfigUserDefaultsStorage: RemoteConfigClient.Storage, @unchecked Sendable {
+
+    private struct Keys {
+        static let config = "config"
+        static let lastFetch = "lastFetch"
+    }
+
+    private let userDefaults: UserDefaults?
+
+    init(instanceName: String? = nil) {
+        var suiteName = "com.amplitude.remoteconfig.cache"
+        if let instanceName {
+            suiteName += "."
+            suiteName += instanceName
+        }
+        userDefaults = UserDefaults(suiteName: suiteName)
+    }
+
+    func fetchConfig() async throws -> RemoteConfigClient.RemoteConfigInfo? {
+        guard let userDefaults,
+              let config = userDefaults.object(forKey: Keys.config) as? RemoteConfigClient.RemoteConfig,
+              let lastFetch = userDefaults.object(forKey: Keys.lastFetch) as? Date else {
+            return nil
+        }
+        return RemoteConfigClient.RemoteConfigInfo(config: config, lastFetch: lastFetch)
+    }
+
+    func setConfig(_ configInfo: RemoteConfigClient.RemoteConfigInfo?) async throws {
+        guard let userDefaults else {
+            return
+        }
+        userDefaults.set(configInfo?.config, forKey: Keys.config)
+        userDefaults.set(configInfo?.lastFetch, forKey: Keys.lastFetch)
+    }
+}

--- a/Tests/AmplitudeCoreTests/RemoteConfigTests.swift
+++ b/Tests/AmplitudeCoreTests/RemoteConfigTests.swift
@@ -1,0 +1,262 @@
+//
+//  RemoteConfigTests.swift
+//  Amplitude-Swift
+//
+//  Created by Chris Leonavicius on 1/16/25.
+//
+
+@testable import AmplitudeCore
+import Foundation
+import XCTest
+
+final class RemoteConfigTests: XCTestCase {
+
+    private static let testSessionConfiguration: URLSessionConfiguration = {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [TestRemoteConfigHandler.self]
+        return configuration
+    }()
+
+    func testRequestsConfigAndUpdatesCache() async throws {
+        let cachedConfig: RemoteConfigClient.RemoteConfig = ["cached": 1]
+        let cachedConfigLastFetch = Date.distantPast
+        let remoteConfig: RemoteConfigClient.RemoteConfig = ["remote": 1]
+        TestRemoteConfigHandler.responseHandler = TestRemoteConfigHandler.successResponseHandler(remoteConfig)
+
+        let storage = RemoteConfigUserDefaultsStorage(instanceName: #function)
+        try await storage.setConfig(RemoteConfigClient.RemoteConfigInfo(config: cachedConfig,
+                                                                        lastFetch: cachedConfigLastFetch))
+
+        let remoteConfigClient = makeRemoteConfigClient(storage: storage)
+
+        let didUpdateConfigExpectation = XCTestExpectation(description: "it did request config")
+        didUpdateConfigExpectation.assertForOverFulfill = true
+        didUpdateConfigExpectation.expectedFulfillmentCount = 2
+        remoteConfigClient.subscribe { config, source, lastFetch in
+            switch source {
+            case .cache:
+                XCTAssertEqual(config as? NSDictionary, cachedConfig as NSDictionary)
+                XCTAssertEqual(lastFetch, cachedConfigLastFetch)
+            case .remote:
+                XCTAssertEqual(config as? NSDictionary, remoteConfig as NSDictionary)
+                XCTAssertNotEqual(lastFetch, cachedConfigLastFetch)
+            }
+
+            didUpdateConfigExpectation.fulfill()
+        }
+
+        await fulfillment(of: [didUpdateConfigExpectation], timeout: 3)
+
+        let storedConfigInfo = try await storage.fetchConfig()
+        XCTAssertEqual(storedConfigInfo?.config as? NSDictionary, remoteConfig as NSDictionary)
+    }
+
+    func testDoesNotUpdateCacheOnError() async throws {
+        let didSendRemoteRequestExpectation = XCTestExpectation(description: "it did request config")
+        didSendRemoteRequestExpectation.expectedFulfillmentCount = 3 // retries
+        TestRemoteConfigHandler.responseHandler = { request in
+            didSendRemoteRequestExpectation.fulfill()
+            return TestRemoteConfigHandler.errorResponseHandler()(request)
+        }
+
+        let storage = RemoteConfigUserDefaultsStorage(instanceName: #function)
+
+        let cachedConfigInfo = RemoteConfigClient.RemoteConfigInfo(config: ["bar": 123],
+                                                                   lastFetch: Date.distantPast)
+        try await storage.setConfig(cachedConfigInfo)
+
+        let remoteConfigClient = makeRemoteConfigClient(storage: storage)
+
+        let didUpdateConfigExpectation = XCTestExpectation(description: "it did request config")
+        remoteConfigClient.subscribe { config, source, lastFetch in
+            XCTAssertEqual(config as? NSDictionary, cachedConfigInfo.config as NSDictionary)
+            XCTAssertEqual(source, .cache)
+            XCTAssertEqual(lastFetch, cachedConfigInfo.lastFetch)
+
+            didUpdateConfigExpectation.fulfill()
+        }
+
+        await fulfillment(of: [didUpdateConfigExpectation, didSendRemoteRequestExpectation], timeout: 3)
+
+        let currentCachedConfigInfo = try await storage.fetchConfig()
+        XCTAssertEqual(currentCachedConfigInfo?.config as? NSDictionary, cachedConfigInfo.config as NSDictionary)
+        XCTAssertEqual(currentCachedConfigInfo?.lastFetch, cachedConfigInfo.lastFetch)
+    }
+
+    func testReturnsNilOnErrorColdStart() async throws {
+        TestRemoteConfigHandler.responseHandler = TestRemoteConfigHandler.errorResponseHandler()
+        let storage = RemoteConfigUserDefaultsStorage(instanceName: #function)
+        try await storage.setConfig(nil)
+
+        let didUpdateConfigExpectation = XCTestExpectation(description: "it did request config")
+        makeRemoteConfigClient(storage: storage).subscribe { config, source, lastFetch in
+            XCTAssertNil(config)
+            XCTAssertNil(lastFetch)
+
+            didUpdateConfigExpectation.fulfill()
+        }
+        await fulfillment(of: [didUpdateConfigExpectation], timeout: 3)
+    }
+
+    // MARK: - Delivery Strategy tests
+
+    func testAllDeliveryStrategy() async {
+        TestRemoteConfigHandler.responseHandler = TestRemoteConfigHandler.successResponseHandler()
+
+        let didReceiveCachedResponseExpecation = XCTestExpectation(description: "it did request cached config")
+        didReceiveCachedResponseExpecation.assertForOverFulfill = true
+
+        let didReceiveRemoteResponseExpecation = XCTestExpectation(description: "it did request remote config")
+        didReceiveRemoteResponseExpecation.assertForOverFulfill = true
+
+        let remoteConfigClient = makeRemoteConfigClient()
+
+        remoteConfigClient.subscribe(deliveryMode: .all) { config, source, _ in
+            switch source {
+            case .cache:
+                didReceiveCachedResponseExpecation.fulfill()
+            case .remote:
+                didReceiveRemoteResponseExpecation.fulfill()
+            }
+        }
+
+        await fulfillment(of: [didReceiveCachedResponseExpecation, didReceiveRemoteResponseExpecation],
+                          timeout: 3,
+                          enforceOrder: true)
+
+        // Future fetches should just return the successful remote response
+        let subsequentFetchExpectation = XCTestExpectation(description: "subsequent fetch")
+        remoteConfigClient.subscribe(deliveryMode: .all) { config, source, _ in
+            switch source {
+            case .cache:
+                XCTFail()
+            case .remote:
+                subsequentFetchExpectation.fulfill()
+            }
+        }
+
+        await fulfillment(of: [subsequentFetchExpectation], timeout: 3)
+    }
+
+    func testWaitForRemoteDeliveryStrategySuccess() async throws {
+        TestRemoteConfigHandler.responseHandler = TestRemoteConfigHandler.successResponseHandler()
+
+        let didReceiveRemoteResponseExpecation = XCTestExpectation(description: "it did request remote config")
+        didReceiveRemoteResponseExpecation.assertForOverFulfill = true
+
+        makeRemoteConfigClient().subscribe(deliveryMode: .waitForRemote()) { config, source, _ in
+            switch source {
+            case .cache:
+                XCTFail()
+            case .remote:
+                didReceiveRemoteResponseExpecation.fulfill()
+            }
+        }
+
+        await fulfillment(of: [didReceiveRemoteResponseExpecation], timeout: 3)
+    }
+
+    func testWaitForRemoteDeliveryStrategyTimeout() async throws {
+        TestRemoteConfigHandler.responseHandler = { request in
+            Thread.sleep(forTimeInterval: 2)
+            return TestRemoteConfigHandler.successResponseHandler()(request)
+        }
+
+        let cachedRemoteConfigInfo = RemoteConfigClient.RemoteConfigInfo(config: ["cached": 1],
+                                                                         lastFetch: Date.distantPast)
+
+        let storage = RemoteConfigUserDefaultsStorage(instanceName: #function)
+        try await storage.setConfig(cachedRemoteConfigInfo)
+
+        let remoteConfigClient = makeRemoteConfigClient(storage: storage)
+
+        let didReceiveLocalResponseExpecation = XCTestExpectation(description: "it did request remote config")
+        didReceiveLocalResponseExpecation.assertForOverFulfill = true
+
+        remoteConfigClient.subscribe(deliveryMode: .waitForRemote(timeout: 1)) { config, source, lastFetch in
+            switch source {
+            case .cache:
+                XCTAssertEqual(config as? NSDictionary, cachedRemoteConfigInfo.config as NSDictionary)
+                XCTAssertEqual(lastFetch, cachedRemoteConfigInfo.lastFetch)
+                didReceiveLocalResponseExpecation.fulfill()
+            case .remote:
+                XCTFail()
+            }
+        }
+
+        await fulfillment(of: [didReceiveLocalResponseExpecation], timeout: 3)
+    }
+
+    // MARK: - Util
+
+    private func makeRemoteConfigClient(storage: RemoteConfigClient.Storage = RemoteConfigUserDefaultsStorage(instanceName: #function)) -> RemoteConfigClient {
+        return RemoteConfigClient(apiKey: "",
+                                  serverUrl: "http://www.amplitude.com",
+                                  storage: storage,
+                                  urlSessionConfiguration: Self.testSessionConfiguration)
+    }
+}
+
+// MARK: TestRemoteConfigHandler
+// A basic echo response that returns {"config": true} for every requested config
+
+class TestRemoteConfigHandler: URLProtocol {
+
+    enum TestRemoteConfigHandlerError: Error {
+        case invalidRequest
+    }
+
+    typealias ResponseHandler = (URLRequest) -> (URLResponse, Data?)
+
+    nonisolated(unsafe) static var responseHandler: ResponseHandler? = nil
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        guard let responseHandler = Self.responseHandler else {
+            client?.urlProtocol(self, didFailWithError: NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown))
+            return
+        }
+
+        let (response, data) = responseHandler(request)
+
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        if let data {
+            client?.urlProtocol(self, didLoad: data)
+        }
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {
+        //no-op
+    }
+
+    static func successResponseHandler(_ config: RemoteConfigClient.RemoteConfig = ["config": true]) -> ResponseHandler {
+        return { request in
+            guard let url = request.url else {
+                return (HTTPURLResponse(url: request.url!, statusCode: 400, httpVersion: nil, headerFields: nil)!, nil)
+            }
+
+            let response = HTTPURLResponse(url: url,
+                                           statusCode: 200,
+                                           httpVersion: nil,
+                                           headerFields: ["Content-Type": "application/json"])!
+
+            let data = try? JSONSerialization.data(withJSONObject: ["configs": config])
+
+            return (response, data)
+        }
+    }
+
+    static func errorResponseHandler(statusCode: Int = 400) -> ResponseHandler {
+        return { request in
+            return (HTTPURLResponse(url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: nil)!, nil)
+        }
+    }
+}


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

**Remote Configuration Spec**

Remote config will always request all available keys for the given platform so that plugins added at any point can have all configs.

Configs are indefinitely cached locally.

In general, newly fetched configs > cached configs > locally configured options in terms of priority. IE, if we have a recent remote config request, we should always return that over any cached values.

Configs should be fetched on initialization of the remote config client. Clients can request that configs are re-fetched but we should add a timeout to prevent this from occurring too often.

APIs:

```
class RemoteConfigClient {
    public enum DeliveryMode : Sendable {
        case all
        case waitForRemote(timeout: TimeInterval = 3)
    }

    public enum CacheMode : Sendable {
        case `static`
        case dynamic
    }

    public enum Source : Sendable {
        case none
        case cache
        case remote
    }

    public typealias RemoteConfig = [String: Sendable]
    public typealias RemoteConfigCallback = @Sendable (RemoteConfig?, Source, Date?) -> Void

    public nonisolated func registerForUpdates(key: String? = nil, 
                                               deliveryMode: DeliveryMode = .all, 
                                               cacheMode: CacheMode = .dynamic, 
                                               callback: @escaping @Sendable RemoteConfigCallback)

    public nonisolated func updateConfigs()
}
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
