### PR TITLE
fix: api changes

### DIFF
--- a/Sources/AmplitudeCore/AnalyticsClient.swift
+++ b/Sources/AmplitudeCore/AnalyticsClient.swift
@@ -1,19 +1,10 @@
 import Foundation
 
-public protocol AnalyticsClientConfiguration {
-    var apiKey: String { get }
+public protocol AnalyticsClient: AnyObject {
+
+    var analyticsContext: AnalyticsContext { get }
+
     var optOut: Bool { get }
-    var serverZone: ServerZone { get }
-    var remoteConfigClient: RemoteConfigClient { get }
-}
-
-public protocol AnalyticsClient<ConfigurationType>: AnyObject {
-
-    associatedtype ConfigurationType: AnalyticsClientConfiguration
-
-    var logger: Logger { get }
-
-    var configuration: ConfigurationType { get }
 
     @discardableResult
     func track(event: BaseEvent) -> Self
@@ -48,15 +39,7 @@ public protocol AnalyticsClient<ConfigurationType>: AnyObject {
 
     // TODO: are these needed?
 /*
-    @discardableResult
-    func add(plugin: Plugin) -> Self
 
-    @discardableResult
-    func remove(plugin: Plugin) -> Self
-
-    func plugin(name: String) -> Plugin?
-
-    func apply(closure: (Plugin) -> Void)
  */
 
     // MARK: Identity

--- a/Sources/AmplitudeCore/AnalyticsContext.swift
+++ b/Sources/AmplitudeCore/AnalyticsContext.swift
@@ -1,0 +1,15 @@
+//
+//  AnalyticsContext.swift
+//  AmplitudeCore
+//
+//  Created by Chris Leonavicius on 3/10/25.
+//
+
+public protocol AnalyticsContext: AnyObject {
+
+    var apiKey: String { get }
+    var serverZone: ServerZone { get }
+    //var remoteConfigClient: RemoteConfigClient { get }
+
+    // TODO: Logging, Diagnostics, etc...
+}

--- a/Sources/AmplitudeCore/PluginHost.swift
+++ b/Sources/AmplitudeCore/PluginHost.swift
@@ -1,0 +1,17 @@
+//
+//  PluginHost.swift
+//  AmplitudeCore
+//
+//  Created by Chris Leonavicius on 3/10/25.
+//
+
+protocol PluginHost {
+
+    @discardableResult
+    func add(plugin: Plugin) -> Self
+
+    @discardableResult
+    func remove(plugin: Plugin) -> Self
+
+    func plugin(name: String) -> Plugin?
+}


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

goals:

I want to try to make the representation of an analytics client we give to plugins as simple as possible, so it's easy to swap in another Analytics SDK like Segment and have all functionality offered in the API contract actually work.

I also want to move us to a more static config setup where possible - currently configs are mutable but at least in our mobile SDKs we aren't always responsive to properties changing after initial setup.
 

changes:

I am proposing a few changes to SDK structure:

1/ Create a new `AnalyticsContext` class, an immutable internal facing config to host utilities and other fixed config items. This would be initialized when the SDK is, and would be the integration point for shared utilities for plugins. In the 3rd party sdk case, this would allow us to provide shared utilities through a simple entry point, vs exposing the whole API of `Configuration` or adding utilities individual properties on the analytics client.

2/ Move `optIn` and `offline` to top level properties on `AnalyticsClient`. These are mutable properties we'd want to report to plugins, this allows access without exposing the entire Configuration object. We would always keep these in sync with similar properties in configuration, which we would deprecate.

3/ Create a new `PluginHost` interface for plugin related methods in Core. Amplitude would implement this interface. 
Basically, I want a namespace that we can add extensions to from blades that is not `AnalyticsClient` itself, so that we don't treat third party SDKs as `PluginHosts`. This would remove the ability for plugins to configure plugins unless we offer a pluginHost through `AnalyticsContext`.

```
// In SessionReplay

extension PluginHost {

  var sessionReplay: SessionReplay {
    return plugin(name: "session replay")
  }
}

```


### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
