### PR TITLE
fix: add binary AmpitudeCoreFramework product

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   
-  #run-tests:
-  #  name: Run Tests
-  #  uses: ./.github/workflows/unit-test.yml
+  run-tests:
+    name: Run Tests
+    uses: ./.github/workflows/unit-test.yml
   
   release:
     name: Release
-    #needs: [authorize, run-tests]
-    needs: [authorize]
+    needs: [authorize, run-tests]
     runs-on: macos-14
     steps:
       - name: Checkout
@@ -63,7 +62,13 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_15.2.app
 
       - name: Build Framework
-        run: swift-create-xcframework/.build/release/swift-create-xcframework AmplitudeCore --no-debug-symbols --stack-evolution --zip
+        run: swift-create-xcframework/.build/release/swift-create-xcframework AmplitudeCore --skip-binary-targets --no-debug-symbols --stack-evolution --zip
+
+      - name: Update Checksum
+        run: |
+          CHECKSUM=$(xcrun swift package compute-checksum AmplitudeCore.zip) && \
+          sed -i '' -E "s/(checksum: \")[^\"]*(\")/\1$CHECKSUM\2/" Package.swift && \
+          sed -i '' -E "s/(checksum: \")[^\"]*(\")/\1$CHECKSUM\2/" Package@swift-5.9.swift
 
       - name: Semantic Release --dry-run
         if: ${{ github.event.inputs.dryRun == 'true'}}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,84 @@
+name: Unit Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_call:
+
+jobs:
+  unit-test:
+    name: Unit ${{ matrix.platform }} - Xcode ${{ matrix.xcode }} - OS ${{ matrix.test-destination-os }}
+    runs-on: macos-15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: iOS
+            xcode: 15.4
+            device: "iPhone 15"
+            test-destination-os: latest
+
+          - platform: macOS
+            xcode: 15.4
+            test-destination-os: latest
+
+          - platform: tvOS
+            xcode: 15.4
+            test-destination-os: latest
+            device: "Apple TV"
+
+          - platform: watchOS
+            xcode: 15.4
+            test-destination-os: latest
+            device: "Apple Watch Series 9 (41mm)"
+
+          # - platform: visionOS
+          #   xcode: 16
+          #   test-destination-os: latest
+          #   device: "Apple Vision Pro"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set Xcode ${{ matrix.xcode }}
+        run: |
+          sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+      - name: ${{ matrix.platform }} Tests
+        run: |
+          case "${{ matrix.platform }}" in
+            iOS)
+              xcodebuild test \
+                -scheme AmplitudeCore-Package \
+                -sdk iphonesimulator \
+                -destination 'platform=iOS Simulator,OS=${{ matrix.test-destination-os }},name=${{ matrix.device }}'
+              ;;
+            macOS)
+              xcodebuild test \
+                -scheme AmplitudeCore-Package \
+                -sdk macosx \
+                -destination 'platform=macosx,OS=${{ matrix.test-destination-os }}'
+              ;;
+            tvOS)
+              xcodebuild \
+                -scheme AmplitudeCore-Package \
+                -sdk appletvsimulator \
+                -destination 'platform=tvOS Simulator,OS=${{ matrix.test-destination-os }},name=${{ matrix.device }}' \
+                test
+              ;;
+            watchOS)
+              xcodebuild \
+                -scheme AmplitudeCore-Package \
+                -sdk watchsimulator \
+                -destination 'platform=watchOS Simulator,OS=${{ matrix.test-destination-os }},name=${{ matrix.device }}' \
+                test
+              ;;
+            visionOS)
+              xcodebuild \
+                -scheme AmplitudeCore-Package \
+                -sdk xrsimulator \
+                -destination 'platform=visionOS Simulator,OS=${{ matrix.test-destination-os }},name=${{ matrix.device }}' \
+                test
+              ;;
+          esac

--- a/.swiftpm/AmplitudeCore-Package.xctestplan
+++ b/.swiftpm/AmplitudeCore-Package.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "B11AB016-9271-4883-94F2-CB3DEFA553A3",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testExecutionOrdering" : "random"
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "AmplitudeCoreTests",
+        "name" : "AmplitudeCoreTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.9
 
 import PackageDescription
 
@@ -9,6 +9,7 @@ let package = Package(
         .iOS(.v11),
         .tvOS(.v11),
         .watchOS(.v4),
+        .visionOS(.v1),
     ],
     products: [
         .library(

--- a/Sources/AmplitudeCore/AnalyticsClient.swift
+++ b/Sources/AmplitudeCore/AnalyticsClient.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public protocol AnalyticsClientConfiguration {
     var apiKey: String { get }
     var optOut: Bool { get }
@@ -7,6 +8,7 @@ public protocol AnalyticsClientConfiguration {
     var remoteConfigClient: RemoteConfigClient { get }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public protocol AnalyticsClient<ConfigurationType>: AnyObject {
 
     associatedtype ConfigurationType: AnalyticsClientConfiguration

--- a/Sources/AmplitudeCore/Plugins/Plugin.swift
+++ b/Sources/AmplitudeCore/Plugins/Plugin.swift
@@ -15,6 +15,7 @@ public enum PluginType: Int, CaseIterable {
     case utility
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public protocol Plugin: AnyObject {
     var type: PluginType { get }
     var name: String? { get }
@@ -27,6 +28,7 @@ public protocol Plugin: AnyObject {
     func onOptOutChanged(_ optOut: Bool)
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public extension Plugin {
 
     var name: String? {

--- a/Sources/AmplitudeCore/Remote Config/RemoteConfigClient.swift
+++ b/Sources/AmplitudeCore/Remote Config/RemoteConfigClient.swift
@@ -7,11 +7,13 @@
 
 import Foundation
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 protocol RemoteConfigStorage: Sendable {
     func fetchConfig() async throws -> RemoteConfigClient.RemoteConfigInfo?
     func setConfig(_ config: RemoteConfigClient.RemoteConfigInfo?) async throws
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public actor RemoteConfigClient: NSObject {
 
     public enum DeliveryMode: Sendable {
@@ -34,7 +36,7 @@ public actor RemoteConfigClient: NSObject {
         case preInit
     }
 
-    private struct Config {
+    struct Config {
         static let usServerURL = "https://sr-client-cfg.amplitude.com/config"
         static let euServerURL = "https://sr-client-cfg.eu.amplitude.com/config"
         static let maxRetries = 3
@@ -343,6 +345,7 @@ public actor RemoteConfigClient: NSObject {
     }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class RemoteConfigUserDefaultsStorage: RemoteConfigStorage, @unchecked Sendable {
 
     private struct Keys {

--- a/Sources/AmplitudeCore/Utilities/HttpUtil.swift
+++ b/Sources/AmplitudeCore/Utilities/HttpUtil.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 struct HttpUtil {
 
     static func makeJsonRequest(url: URL,

--- a/release.config.js
+++ b/release.config.js
@@ -19,10 +19,10 @@ module.exports = {
           { "path": "AmplitudeCore.zip" },
         ]
     }],
-    // [
-    //   "@google/semantic-release-replace-plugin",
-    //   {
-    //     "replacements": [
+     [
+       "@google/semantic-release-replace-plugin",
+       {
+         "replacements": [
     //       {
     //         "files": ["AmplitudeCore.podspec"],
     //         "from": "amplitude_core_version = \".*\"",
@@ -37,39 +37,31 @@ module.exports = {
     //         ],
     //         "countMatches": true
     //       },
-    //       {
-    //         "files": ["Package.swift"],
-    //         "from": "https://github.com/amplitude/AmplitudeCore-Swift/releases/download/v.*/AmplitudeCore.zip",
-    //         "to": "https://github.com/amplitude/AmplitudeCore-Swift/releases/download/v${nextRelease.version}/AmplitudeCore.zip",
-    //         "results": [
-    //           {
-    //             "file": "Package.swift",
-    //             "hasChanged": true,
-    //             "numMatches": 1,
-    //             "numReplacements": 1
-    //           }
-    //         ],
-    //         "countMatches": true
-    //       },
-    //       {
-    //         "files": ["Package@swift-5.9.swift"],
-    //         "from": "https://github.com/amplitude/AmplitudeCore-Swift/releases/download/v.*/AmplitudeCore.xcframework.zip",
-    //         "to": "https://github.com/amplitude/AmplitudeCore-Swift/releases/download/v${nextRelease.version}/AmplitudeCore.xcframework.zip",
-    //         "results": [
-    //           {
-    //             "file": "Package@swift-5.9.swift",
-    //             "hasChanged": true,
-    //             "numMatches": 1,
-    //             "numReplacements": 1
-    //           }
-    //         ],
-    //         "countMatches": true
-    //       },
-    //     ]
-    //   }
-    // ],
+          {
+            "files": ["Package.swift", "Package@swift-5.9.swift"],
+            "from": "https://github.com/amplitude/AmplitudeCore-Swift/releases/download/v.*/AmplitudeCore.zip",
+            "to": "https://github.com/amplitude/AmplitudeCore-Swift/releases/download/v${nextRelease.version}/AmplitudeCore.zip",
+            "results": [
+              {
+                "file": "Package.swift",
+                "hasChanged": true,
+                "numMatches": 1,
+                "numReplacements": 1
+              },
+              {
+                "file": "Package@swift-5.9.swift",
+                "hasChanged": true,
+                "numMatches": 1,
+                "numReplacements": 1
+              }
+            ],
+            "countMatches": true
+          },
+        ]
+      }
+    ],
     ["@semantic-release/git", {
-      "assets": [/*"AmplitudeCore.podspec", */"CHANGELOG.md",/* "Package.swift", "Package@swift-5.9.swift"*/],
+      "assets": [/*"AmplitudeCore.podspec", */"CHANGELOG.md", "Package.swift", "Package@swift-5.9.swift"],
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }],
     // ["@semantic-release/exec", {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- runs unit tests in CI and attempts to make them more reliable (not 100% yet :( )
- move min version back to match experiment. We will require iOS 13 to match amplitude-swift for most core features.
- temporarily disable visionos tests, as they try to link the compiled framework as a dependency, which doesn't support visionos right now.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
