### PR TITLE
fix: generate objc modulemap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         run: sudo xcode-select -switch /Applications/Xcode_15.2.app
 
       - name: Build Framework
-        run: swift-create-xcframework/.build/release/swift-create-xcframework AmplitudeCore --skip-binary-targets --no-debug-symbols --stack-evolution --zip
+        run: swift-create-xcframework/.build/release/swift-create-xcframework AmplitudeCore --skip-binary-targets --no-debug-symbols --stack-evolution --xc-setting DEFINES_MODULE=1 --zip
 
       - name: Update Checksum
         run: |


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Enables (automatic) module map generation for objc compatibility.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
