### PR TITLE
fix: add carthage support via binary format

### DIFF
--- a/docs/Carthage/AmplitudeCore.json
+++ b/docs/Carthage/AmplitudeCore.json
@@ -1,0 +1,3 @@
+{
+  "1.0.6": "https://github.com/amplitude/AmplitudeCore-Swift/releases/download/v1.0.6/AmplitudeCore.zip"
+}

--- a/release.config.js
+++ b/release.config.js
@@ -60,8 +60,11 @@ module.exports = {
           ]
         }
       ],
+      ["@semantic-release/exec", {
+        "prepareCmd": "cat docs/Carthage/AmplitudeCore.json | jq --arg RELEASE ${nextRelease.version} '. + {$RELEASE: \"https://github.com/amplitude/AmplitudeCore-Swift/releases/download/v\($RELEASE)/AmplitudeCore.zip\"}' | tee docs/Carthage/AmplitudeCore.json"
+      }],
       ["@semantic-release/git", {
-        "assets": ["AmplitudeCore.podspec", "CHANGELOG.md", "Package.swift", "Package@swift-5.9.swift"],
+        "assets": ["AmplitudeCore.podspec", "CHANGELOG.md", "Package.swift", "Package@swift-5.9.swift", "Carthage/AmplitudeCore.json"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }],
        ["@semantic-release/exec", {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

This adds Carthage support for Amplitude-Core, as we can't break existing Carthage support for Amplitude-Swift and Experiment that will soon depend on Core.

Core runs directly from a Package.swift, we don't have an xcodeproject, so Carthage is not able to add it as a dependency by default. We could either add a dummy Xcode project with just enough to enable Carthage to see which frameworks to download (it already searches GitHub releases for precompiled versions), or use their binary format, which is just a json file. I'm trying the binary format as we'd probably have to get it working to distribute Session Replay anyways, should we provide Carthage support for SR/Unified.

I plan on making the `docs` directory the root of a new GitHub pages source for easier hosting, so (hopefully) this will be able to be added to a cartfile as something like `binary "https://amplitude.github.io/AmplitudeCore-Swift/Carthage/AmplitudeCore.json"`

We can change the root directory for hosting to something else, docs was a GitHub default for a while.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no
