### PR TITLE
fix: use config group vs specifying individual config keys

### DIFF
--- a/Sources/AmplitudeCore/Remote Config/RemoteConfigClient.swift
+++ b/Sources/AmplitudeCore/Remote Config/RemoteConfigClient.swift
@@ -41,11 +41,7 @@ public actor RemoteConfigClient: NSObject {
         static let euServerURL = "https://sr-client-cfg.eu.amplitude.com/config"
         static let maxRetries = 3
         static let minTimeBetweenFetches: TimeInterval = 5 * 60
-        static let fetchedKeys = [
-            "sessionReplay.sr_ios_privacy_config",
-            "sessionReplay.sr_ios_sampling_config",
-            "analyticsSDK.browserSDK",
-        ]
+        static let group = "ios"
     }
 
     private class CallbackInfo {
@@ -328,14 +324,10 @@ public actor RemoteConfigClient: NSObject {
             throw RemoteConfigError.invalidServerURL
         }
 
-        var queryItems: [URLQueryItem] = []
-        queryItems.append(URLQueryItem(name: "api_key", value: apiKey))
-
-        for configKey in Config.fetchedKeys {
-            queryItems.append(URLQueryItem(name: "config_keys", value: configKey))
-        }
-
-        urlComponents.queryItems = queryItems
+        urlComponents.queryItems = [
+            URLQueryItem(name: "api_key", value: apiKey),
+            URLQueryItem(name: "config_group", value: Config.group),
+        ]
 
         guard let url = urlComponents.url else {
             throw RemoteConfigError.invalidServerURL


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Uses the new `config_group` remote config url, vs relying on specific keys in the SDKs

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
