### PR TITLE
fix: build for maccataylst

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,20 @@ jobs:
         run: pod lib lint
 
       - name: Build Framework
-        run: swift-create-xcframework/.build/release/swift-create-xcframework AmplitudeCore --skip-binary-targets --no-debug-symbols --stack-evolution --xc-setting DEFINES_MODULE=1 --zip
+        run: |
+          swift-create-xcframework/.build/release/swift-create-xcframework \
+          AmplitudeCore \
+          --platform ios \
+          --platform maccatalyst \
+          --platform macos \
+          --platform tvos \
+          --platform watchos \
+          --platform visionos \
+          --skip-binary-targets \
+          --no-debug-symbols \
+          --stack-evolution \
+          --xc-setting DEFINES_MODULE=1 \
+          --zip
 
       - name: Update Checksum
         run: |


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

swift-create-xcframework does not create Mac Catalyst builds by default as you cannot specify the platform in a Package.swift. Amplitude-Swift does link Mac-catalyst though, so we need to include it in our builds.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
