### PR TITLE
fix: cancel in-progress requests when RemoteConfigClient is deallocated

### DIFF
--- a/Tests/AmplitudeCoreTests/RemoteConfigTests.swift
+++ b/Tests/AmplitudeCoreTests/RemoteConfigTests.swift
@@ -98,7 +98,8 @@ final class RemoteConfigTests: XCTestCase {
         try await storage.setConfig(nil)
 
         let didUpdateConfigExpectation = XCTestExpectation(description: "it did request config")
-        makeRemoteConfigClient(storage: storage).subscribe { config, source, lastFetch in
+        let remoteConfigClient = makeRemoteConfigClient(storage: storage)
+        remoteConfigClient.subscribe { config, source, lastFetch in
             XCTAssertNil(config)
             XCTAssertNil(lastFetch)
 
@@ -158,7 +159,8 @@ final class RemoteConfigTests: XCTestCase {
         let didReceiveRemoteResponseExpecation = XCTestExpectation(description: "it did request remote config")
         didReceiveRemoteResponseExpecation.assertForOverFulfill = true
 
-        makeRemoteConfigClient().subscribe(deliveryMode: .waitForRemote()) { config, source, _ in
+        let remoteConfigClient = makeRemoteConfigClient()
+        remoteConfigClient.subscribe(deliveryMode: .waitForRemote()) { config, source, _ in
             switch source {
             case .cache:
                 XCTFail()


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Tests for https://github.com/amplitude/Amplitude-Swift/pull/284 are failing as clients created in tests are continually sending remote config retries, even after deallocation.

- Detaches some tasks from the Remote config actor so we can cancel them when needed
- Returned subscription token is Sendable
- fixes tests so remote config client doesn't deallocate

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
