### PR TITLE
fix: add jitter to remote config retries

### DIFF
--- a/Tests/AmplitudeCoreTests/RemoteConfigTests.swift
+++ b/Tests/AmplitudeCoreTests/RemoteConfigTests.swift
@@ -213,7 +213,8 @@ final class RemoteConfigTests: XCTestCase {
         return RemoteConfigClient(apiKey: "",
                                   serverUrl: "http://www.amplitude.com",
                                   storage: storage,
-                                  urlSessionConfiguration: Self.testSessionConfiguration)
+                                  urlSessionConfiguration: Self.testSessionConfiguration,
+                                  maxRetryDelay: 0.1)
     }
 }
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Adds jitter to remote config requests, with better backoff

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
