### PR TITLE
fix: restore deleted carthage manifest

### DIFF
--- a/docs/Carthage/AmplitudeCore.json
+++ b/docs/Carthage/AmplitudeCore.json
@@ -1,0 +1,6 @@
+{
+"1.0.6": "https://github.com/amplitude/AmplitudeCore-Swift/releases/download/v1.0.6/AmplitudeCore.zip",
+"1.0.8": "https://github.com/amplitude/AmplitudeCore-Swift/releases/download/v1.0.8/AmplitudeCore.zip",
+"1.0.9": "https://github.com/amplitude/AmplitudeCore-Swift/releases/download/v1.0.9/AmplitudeCore.zip",
+"1.0.10": "https://github.com/amplitude/AmplitudeCore-Swift/releases/download/v1.0.10/AmplitudeCore.zip"
+}

--- a/release.config.js
+++ b/release.config.js
@@ -61,7 +61,7 @@ module.exports = {
         }
       ],
       ["@semantic-release/exec", {
-        "prepareCmd": "cat docs/Carthage/AmplitudeCore.json | jq --arg RELEASE ${nextRelease.version} '. + {$RELEASE: \"https://github.com/amplitude/AmplitudeCore-Swift/releases/download/v\\($RELEASE)/AmplitudeCore.zip\"}' | tee docs/Carthage/AmplitudeCore.json"
+        "prepareCmd": "cat docs/Carthage/AmplitudeCore.json | jq --arg RELEASE '${nextRelease.version}' '. + {$RELEASE: \"https://github.com/amplitude/AmplitudeCore-Swift/releases/download/v\\($RELEASE)/AmplitudeCore.zip\"}' | tee docs/Carthage/AmplitudeCore.json"
       }],
       ["@semantic-release/git", {
         "assets": ["AmplitudeCore.podspec", "CHANGELOG.md", "Package.swift", "Package@swift-5.9.swift", "docs/Carthage/AmplitudeCore.json"],


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

The release for 1.0.10 deleted the carthage manifest (https://github.com/amplitude/AmplitudeCore-Swift/commit/3eb8c43373bb60f82456fa059cfedcd73466b6f9). This restores it. 
It doesn't look like anything changed in terms of release scripts between the successful 1.0.9 release and unsuccessful 1.10 release, but I've updated the script to quote the version number, in case that helps.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
