### PR TITLE
fix: use binary framework for cocoapods

### DIFF
--- a/AmplitudeCore.podspec
+++ b/AmplitudeCore.podspec
@@ -7,11 +7,6 @@ Pod::Spec.new do |s|
   s.homepage               = "https://amplitude.com"
   s.license                = { :type => "MIT" }
   s.author                 = { "Amplitude" => "dev@amplitude.com" }
-  s.source                 = { :git => "https://github.com/amplitude/AmplitudeCore-Swift.git", :tag => "v#{s.version}" }
-
-  s.source_files           = 'Sources/AmplitudeCore/**/*.{h,swift}'
-  s.resource_bundle        = { 'AmplitudeCore': ['Sources/AmplitudeCore/PrivacyInfo.xcprivacy'] }
-  s.swift_version          = '5.9'
 
   s.ios.deployment_target  = '11.0'
   s.tvos.deployment_target = '11.0'
@@ -19,5 +14,6 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target  = '4.0'
   s.visionos.deployment_target = '1.0'
 
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+  s.source                 = { :http => "https://github.com/amplitude/AmplitudeCore-Swift/releases/download/v#{amplitude_core_version}/AmplitudeCore.zip" }
+  s.vendored_frameworks    = "AmplitudeCore.xcframework"
 end


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Uses binary framework for cocoapods. this fixes build issues with incompatible swift versions sr is already linked against the binary version

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
