### PR TITLE
fix: create framework before pod validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,9 +61,6 @@ jobs:
       - name: Set Xcode Version
         run: sudo xcode-select -switch /Applications/Xcode_15.2.app
 
-      - name: Validate Podfile
-        run: pod lib lint
-
       - name: Build Framework
         run: |
           swift-create-xcframework/.build/release/swift-create-xcframework \
@@ -79,6 +76,10 @@ jobs:
           --stack-evolution \
           --xc-setting DEFINES_MODULE=1 \
           --zip
+
+      - name: Validate Podfile
+        run: |
+          unzip AmplitudeCore.zip && pod lib lint
 
       - name: Update Checksum
         run: |


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

`pod lib lint` works with local specs and won't download http sources. so, we must build the framework and place it where pod lib lint expects it to be.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
