### PR TITLE
fix: allow warnings for cocoapods release

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -68,7 +68,7 @@ module.exports = {
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }],
        ["@semantic-release/exec", {
-         "publishCmd": "pod trunk push AmplitudeCore.podspec",
+         "publishCmd": "pod trunk push AmplitudeCore.podspec --allow-warnings",
        }],
     ],
   }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

allow warnings when releasing pod

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
