### PR TITLE
fix: restore carthage json again

### DIFF
--- a/docs/Carthage/AmplitudeCore.json
+++ b/docs/Carthage/AmplitudeCore.json
@@ -1,0 +1,7 @@
+{
+  "1.0.6": "https://github.com/amplitude/AmplitudeCore-Swift/releases/download/v1.0.6/AmplitudeCore.zip",
+  "1.0.8": "https://github.com/amplitude/AmplitudeCore-Swift/releases/download/v1.0.8/AmplitudeCore.zip",
+  "1.0.9": "https://github.com/amplitude/AmplitudeCore-Swift/releases/download/v1.0.9/AmplitudeCore.zip",
+  "1.0.10": "https://github.com/amplitude/AmplitudeCore-Swift/releases/download/v1.0.10/AmplitudeCore.zip",
+  "1.0.11": "https://github.com/amplitude/AmplitudeCore-Swift/releases/download/v1.0.11/AmplitudeCore.zip"
+}


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Carthage JSON was erased again in the release, restoring now and ill take another look at the script

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
