### PR TITLE
fix: add plugin lookup by type

### DIFF
--- a/Sources/AmplitudeCore/Plugins/PluginHost.swift
+++ b/Sources/AmplitudeCore/Plugins/PluginHost.swift
@@ -8,5 +8,15 @@
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public protocol PluginHost {
 
-    func plugin(name: String) -> (UniversalPlugin)?
+    func plugin(name: String) -> UniversalPlugin?
+
+    func plugins<PluginType: UniversalPlugin>(type: PluginType.Type) -> [PluginType]
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public extension PluginHost {
+
+    func plugins<PluginType: UniversalPlugin>(type: PluginType.Type) -> [PluginType] {
+        return []
+    }
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Background: Experiment needs to be able to attach multiple instances of itself to a single amplitude instance. This breaks the expected plugin by name lookup where we can get the exact instance from a static name. 

Usual setups will still only have one experiment plugin attached, so we still could return that single plugin (if it is the only one) as `amplitudeInstance.experiment` if we could query attached plugins by type.

Possible implementation in Amplitude-Swift:

```
public func plugins<PluginType: UniversalPlugin>(type: PluginType.Type) -> [PluginType] {
        var typedPlugins: [PluginType] = []
        timeline.apply { plugin in
            if let typedPlugin = plugin as? PluginType {
                typedPlugins.append(typedPlugin)
            }
        }
        return typedPlugins
    }
```

which would enable us to return the single experiment plugin attached to amplitude as `amplitude.experiment`:

```
public var experiment: ExperimentClient? {
        let plugins = plugins(type: ExperimentPlugin.self)
        // If there's only one experiment instance attached, we can reference it directly
        if plugins.count == 1 {
            return plugins.first?.experiment
        } else {
            return nil
        }
    }
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
