### PR TITLE
fix: fix crash on iOS 14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   authorize:
     name: Authorize
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: ${{ github.actor }} permission check to do a release
         uses: octokit/request-action@v2.x
@@ -28,7 +28,7 @@ jobs:
   release:
     name: Release
     needs: [authorize, run-tests]
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -37,7 +37,7 @@ jobs:
         # See https://github.com/swiftlang/swift-package-manager/issues/4651
         # NOTE: if downgrading, you may have to manually delete the actions cache via the github interface
       - name: Set Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_16.2.app
+        run: sudo xcode-select -switch /Applications/Xcode_16.3.app
 
       - name: Checkout swift-create-xcframework
         uses: actions/checkout@v4
@@ -57,9 +57,6 @@ jobs:
 
       - name: Build swift-create-xcframework
         run: make -C swift-create-xcframework swift-create-xcframework
-
-      - name: Set Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_16.1.app
 
       - name: Build Framework
         run: |


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Fixed a crash on iOS 14. 

The root cause:  
We used Xcode 16.1 in GitHub Actions to generate the precompiled `AmplitudeCore.xcframework`, but **Xcode versions prior to 16.3 have a bug** where the concurrency library linked by binary xcframework was `/usr/lib/swift/libswift_Concurrency.dylib` instead of `@rpath/libswift_Concurrency.dylib`. This caused the app to fail to locate `libswift_Concurrency` properly on iOS versions earlier than 15.  

Upgrading the toolchain to Xcode 16.3 resolves the issue, but also requires users to develop using Xcode 16.3 or later.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
