### PR TITLE
fix: include dSYM file for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,11 +20,11 @@ jobs:
           repository: ${{ github.repository }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
+
   run-tests:
     name: Run Tests
     uses: ./.github/workflows/unit-test.yml
-  
+
   release:
     name: Release
     needs: [authorize, run-tests]
@@ -69,7 +69,6 @@ jobs:
           --platform watchos \
           --platform visionos \
           --skip-binary-targets \
-          --no-debug-symbols \
           --stack-evolution \
           --xc-setting DEFINES_MODULE=1 \
           --zip


### PR DESCRIPTION
### Summary
AmplitudeCore-Swift releases were not including dSYM files, which prevents customers from being able to provide symbolicated stack traces. It also caused warnings when attempting to upload archive files to the App Store ([Amplitude-Flutter #264](https://github.com/amplitude/Amplitude-Flutter/issues/264)). This PR removes the `--no-debug-symbols` flag from the build process to include the dSYM file. 

Tested locally by running the following command and seeing a dSYM folder/file included.

```
swift create-xcframework AmplitudeCore \
          --platform ios \
          --skip-binary-targets \
          --stack-evolution \
          --xc-setting DEFINES_MODULE=1 \
          --zip
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
