### PR TITLE
fix: prevent fetchRemoteTask was called before _updateConfigs finished

### DIFF
--- a/Sources/AmplitudeCore/Remote Config/RemoteConfigClient.swift
+++ b/Sources/AmplitudeCore/Remote Config/RemoteConfigClient.swift
@@ -36,6 +36,7 @@ public actor RemoteConfigClient: NSObject {
         case badResponse
         case preInit
         case cancelled
+        case clientUnavailable
     }
 
     struct Config {
@@ -91,6 +92,7 @@ public actor RemoteConfigClient: NSObject {
     private var fetchLocalTask: Task<RemoteConfigInfo, Error>
     private var fetchRemoteTask: Task<RemoteConfigInfo, Error>
     private var callbacks: [CallbackInfo] = []
+    private var initializationTask: Task<Void, Never>?
 
     public init(apiKey: String,
                 serverZone: ServerZone,
@@ -135,7 +137,7 @@ public actor RemoteConfigClient: NSObject {
 
         super.init()
 
-        Task {
+        initializationTask = Task {
             await _updateConfigs()
         }
     }
@@ -167,12 +169,16 @@ public actor RemoteConfigClient: NSObject {
         let callbackInfo = CallbackInfo(id: id, key: key, deliveryMode: deliveryMode, callback: callback)
         callbacks.append(callbackInfo)
 
-        Task.detached { [weak self, fetchLocalTask, fetchRemoteTask] in
+        Task.detached { [weak self, fetchLocalTask, initializationTask] in
             switch callbackInfo.deliveryMode {
             case .all:
-                await withThrowingTaskGroup(of: (configInfo: RemoteConfigInfo, source: Source).self) { [fetchLocalTask, fetchRemoteTask] taskGroup in
+                await withThrowingTaskGroup(of: (configInfo: RemoteConfigInfo, source: Source).self) { [fetchLocalTask, initializationTask] taskGroup in
                     // send remote first, if it's already complete we can skip the cached response
                     taskGroup.addTask {
+                        await initializationTask?.value
+                        guard let fetchRemoteTask = await self?.fetchRemoteTask else {
+                            throw RemoteConfigError.clientUnavailable
+                        }
                         return (try await fetchRemoteTask.value, .remote)
                     }
                     await Task.yield()
@@ -201,6 +207,10 @@ public actor RemoteConfigClient: NSObject {
                 }
             case .waitForRemote(timeout: let timeout):
                 let fetchTask = Task {
+                    await initializationTask?.value
+                    guard let fetchRemoteTask = await self?.fetchRemoteTask else {
+                        throw RemoteConfigError.clientUnavailable
+                    }
                     let config = try await fetchRemoteTask.value
                     try Task.checkCancellation()
                     return config
@@ -257,6 +267,7 @@ public actor RemoteConfigClient: NSObject {
      */
     public nonisolated func updateConfigs() {
         Task.detached { [weak self] in
+            await self?.initializationTask?.value
             guard let fetchRemoteTask = await self?.fetchRemoteTask else {
                 return
             }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

If `subscribe` or `updateConfigs` were called instantly after RemoteConfigClient initialization, there is a chance that `fetchRemoteTask` is still the `preInit` one. This causes the unit tests to fail frequently.
Await `_updateConfigs` before calling `fetchRemoteTask` to resolve this issue.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no
