### PR TITLE
fix: remove an unexpected diagnostics basic tag

### DIFF
--- a/Sources/AmplitudeCore/Diagnostics/DiagnosticsClient.swift
+++ b/Sources/AmplitudeCore/Diagnostics/DiagnosticsClient.swift
@@ -263,7 +263,6 @@ public actor DiagnosticsClient: CoreDiagnostics {
         let device = await CoreDevice.current
         staticContext["device_manufacturer"] = await device.manufacturer
         staticContext["device_model"] = await device.model
-        staticContext["idfv"] = await device.identifierForVendor
         staticContext["os_name"] = await device.os_name
         staticContext["os_version"] = await device.os_version
         staticContext["platform"] = await device.platform


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

remove an unexpected diagnostics basic tag

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes collection of the `idfv` basic tag from diagnostics.
> 
> - In `DiagnosticsClient.swift`, drops setting `staticContext["idfv"]` in `setupBasicDiagnosticsTags`, so device Identifier for Vendor is no longer sent as a diagnostics tag
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34c7e930e2e8789111ba94252aad8833144475e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->