### PR TITLE
chore: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         # See https://github.com/swiftlang/swift-package-manager/issues/4651
         # NOTE: if downgrading, you may have to manually delete the actions cache via the github interface
       - name: Set Xcode Version
-        run: sudo xcode-select -switch /Applications/Xcode_16.3.app
+        run: sudo xcode-select -switch /Applications/Xcode_16.4.app
 
       - name: Checkout swift-create-xcframework
         uses: actions/checkout@v4

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -10,34 +10,34 @@ on:
 jobs:
   unit-test:
     name: Unit ${{ matrix.platform }} - Xcode ${{ matrix.xcode }} - OS ${{ matrix.test-destination-os }}
-    runs-on: macos-15
+    runs-on: macos-26
 
     strategy:
       fail-fast: false
       matrix:
         include:
           - platform: iOS
-            xcode: 16.4
-            device: "iPhone 16"
-            test-destination-os: latest
+            xcode: 26.2
+            device: "iPhone 17"
+            test-destination-os: 26.2
 
           - platform: macOS
-            xcode: 16.4
+            xcode: 26.2
             test-destination-os: latest
 
           - platform: tvOS
-            xcode: 16.4
-            test-destination-os: latest
+            xcode: 26.2
+            test-destination-os: 26.2
             device: "Apple TV"
 
           - platform: watchOS
-            xcode: 16.4
-            test-destination-os: latest
-            device: "Apple Watch Series 10 (42mm)"
+            xcode: 26.2
+            test-destination-os: 26.2
+            device: "Apple Watch Series 11 (42mm)"
 
           - platform: visionOS
-            xcode: 16.4
-            test-destination-os: 2.5
+            xcode: 26.2
+            test-destination-os: 26.2
             device: "Apple Vision Pro"
     steps:
       - name: Checkout


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

GitHub deprecated simulator runtimes for Xcode 16.3 and older on macOS 15, but it seems to have a larger impact; the macos-15 runner is not very stable. Therefore, also update the UT to macos-26.

Test action:
https://github.com/amplitude/AmplitudeCore-Swift/actions/runs/21049439441

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes CI to address deprecated runtimes and runner instability.
> 
> - Updates `unit-test.yml` to run on `macos-26` with Xcode `26.2`; sets iOS/tvOS/watchOS/visionOS simulators to `26.2` and updates devices (e.g., iPhone 17, Apple Watch Series 11)
> - Adjusts `release.yml` to select Xcode `16.4` for building xcframeworks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 875c774525c0f30b4e8d51ab88fa3b50f69fd897. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->