### PR TITLE
chore: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,16 @@ jobs:
       - name: Set Xcode Version
         run: sudo xcode-select -switch /Applications/Xcode_16.3.app
 
+      - name: Install Apple platform SDKs
+        run: |
+          # Warm up CoreSimulator to avoid "Unable to connect to simulator":
+          # https://github.com/actions/runner-images/issues/12862#issuecomment-3239326872
+          xcrun simctl list > /dev/null
+          sudo xcodebuild -downloadPlatform iOS
+          sudo xcodebuild -downloadPlatform tvOS
+          sudo xcodebuild -downloadPlatform watchOS
+          sudo xcodebuild -downloadPlatform visionOS
+
       - name: Checkout swift-create-xcframework
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -45,6 +45,25 @@ jobs:
       - name: Set Xcode ${{ matrix.xcode }}
         run: |
           sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
+      - name: Install Apple platform SDKs
+        run: |
+          # Warm up CoreSimulator to avoid "Unable to connect to simulator":
+          # https://github.com/actions/runner-images/issues/12862#issuecomment-3239326872
+          xcrun simctl list > /dev/null
+          case "${{ matrix.platform }}" in
+            iOS)
+              sudo xcodebuild -downloadPlatform iOS
+              ;;
+            tvOS)
+              sudo xcodebuild -downloadPlatform tvOS
+              ;;
+            watchOS)
+              sudo xcodebuild -downloadPlatform watchOS
+              ;;
+            visionOS)
+              sudo xcodebuild -downloadPlatform visionOS
+              ;;
+          esac
       - name: ${{ matrix.platform }} Tests
         run: |
           case "${{ matrix.platform }}" in


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Add platform download to avoid ut and release run fails
- release: tooks extra 8 mins 
- ut: tooks extra 3 mins for each platform if needed to download

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds explicit SDK downloads to CI to ensure simulators/platforms are present.
> 
> - **release.yml:** New `Install Apple platform SDKs` step warms `CoreSimulator` and downloads `iOS`, `tvOS`, `watchOS`, and `visionOS` via `xcodebuild -downloadPlatform`
> - **unit-test.yml:** New `Install Apple platform SDKs` step warms `CoreSimulator` and conditionally downloads the SDK matching the matrix `platform` (iOS/tvOS/watchOS/visionOS)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e1f68f8b29a94648e7f0ba65c621c69264c0532. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->