### PR TITLE
fix: add fnv1a64String helper func

### DIFF
--- a/Sources/AmplitudeCore/Diagnostics/DiagnosticsStorage.swift
+++ b/Sources/AmplitudeCore/Diagnostics/DiagnosticsStorage.swift
@@ -40,7 +40,7 @@ actor DiagnosticsStorage {
         self.instanceName = instanceName
         self.logger = logger
         self.sessionStartAt = sessionStartAt
-        self.sanitizedInstance = Self.sanitize(instanceName)
+        self.sanitizedInstance = instanceName.fnv1a64String()
         self.persistIntervalNanoSec = persistIntervalNanoSec
         self.shouldStore = shouldStore
     }
@@ -441,11 +441,6 @@ actor DiagnosticsStorage {
         } else {
             fileHandle.synchronizeFile()
         }
-    }
-
-    private static func sanitize(_ value: String) -> String {
-        let hash = Hash.fnv1a64(value)
-        return String(format: "%016llx", hash)
     }
 
     // MARK: - Persistence Timer

--- a/Sources/AmplitudeCore/Utilities/StringExtension.swift
+++ b/Sources/AmplitudeCore/Utilities/StringExtension.swift
@@ -80,3 +80,11 @@ public extension String {
     }
 
 }
+
+public extension String {
+
+    func fnv1a64String() -> String {
+        let hash = Hash.fnv1a64(self)
+        return String(format: "%016llx", hash)
+    }
+}


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

add a public fnv1a64String helper func

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a reusable FNV-1a 64-bit hash helper and updates diagnostics to use it.
> 
> - Adds public `String.fnv1a64String()` in `StringExtension.swift` (formats `Hash.fnv1a64` as 16-char hex)
> - `DiagnosticsStorage` now uses `fnv1a64String()` for `sanitizedInstance`; removes the private `sanitize` method
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 194ed3c4322bf8112e954265b188adbe902a833e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->