### PR TITLE
feat: rename LogLevel -> AMPLogLevel for ObjC

### DIFF
--- a/Sources/AmplitudeCore/Logger/CoreLogger.swift
+++ b/Sources/AmplitudeCore/Logger/CoreLogger.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-@objc
+@objc(AMPCoreLogLevel)
 public enum LogLevel: Int, Comparable, Sendable {
 
     case off = 0
@@ -36,7 +36,7 @@ public enum LogLevel: Int, Comparable, Sendable {
     }
 }
 
-@objc
+@objc(AMPCoreLogger)
 @preconcurrency
 public protocol CoreLogger: AnyObject, Sendable {
     func error(message: String)


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

We have some reports of the unprefixed LogLevel enum having conflicts in ObjC. Our only fix is to rename it. Note that this is a breaking change of ObjC clients who use log levels.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  yes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Objective-C name prefixes to avoid collisions.
> 
> - Renames exposed ObjC enum name to `AMPCoreLogLevel` for `LogLevel`
> - Renames exposed ObjC protocol name to `AMPCoreLogger` for `CoreLogger`
> 
> No functional/logic changes in Swift; only ObjC symbol names updated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f5131077f8e2f3ed78216da468f867b65cec64f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->