### PR TITLE
fix: crash while getting patform string

### DIFF
--- a/Sources/AmplitudeCore/Device/CoreDevice.swift
+++ b/Sources/AmplitudeCore/Device/CoreDevice.swift
@@ -84,18 +84,21 @@ public class CoreDevice: Sendable {
             #endif
         }
 
-        private func getPlatformString() -> String {
+        private func getPlatformString() -> String? {
             var name: [Int32] = [CTL_HW, HW_MACHINE]
-            var size: Int = 2
-            sysctl(&name, 2, nil, &size, nil, 0)
-            var hw_machine = [CChar](repeating: 0, count: Int(size))
-            sysctl(&name, 2, &hw_machine, &size, nil, 0)
-            let platform = String(cString: hw_machine)
-            return platform
+            var size: Int = 0
+            guard sysctl(&name, 2, nil, &size, nil, 0) == 0, size > 0 else {
+                return nil
+            }
+            var hw_machine = [CChar](repeating: 0, count: size + 1)
+            guard sysctl(&name, 2, &hw_machine, &size, nil, 0) == 0 else {
+                return nil
+            }
+            return String(cString: hw_machine)
         }
 
         private func deviceModel() -> String {
-            let platform = getPlatformString()
+            let platform = getPlatformString() ?? "unknown"
             return getDeviceModel(platform: platform)
         }
     }
@@ -234,18 +237,21 @@ public class CoreDevice: Sendable {
             return "watchOS"
         }
 
-        private func getPlatformString() -> String {
+        private func getPlatformString() -> String? {
             var name: [Int32] = [CTL_HW, HW_MACHINE]
-            var size: Int = 2
-            sysctl(&name, 2, nil, &size, nil, 0)
-            var hw_machine = [CChar](repeating: 0, count: Int(size))
-            sysctl(&name, 2, &hw_machine, &size, nil, 0)
-            let platform = String(cString: hw_machine)
-            return platform
+            var size: Int = 0
+            guard sysctl(&name, 2, nil, &size, nil, 0) == 0, size > 0 else {
+                return nil
+            }
+            var hw_machine = [CChar](repeating: 0, count: size + 1)
+            guard sysctl(&name, 2, &hw_machine, &size, nil, 0) == 0 else {
+                return nil
+            }
+            return String(cString: hw_machine)
         }
 
         private func deviceModel() -> String {
-            let platform = getPlatformString()
+            let platform = getPlatformString() ?? "unknown"
             return getDeviceModel(platform: platform)
         }
     }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

- guard on sysctl result
- buffer size + 1 to guarantee null termination cstring

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change limited to device model detection; it only adds error handling and a safe fallback when `sysctl` fails.
> 
> **Overview**
> Fixes a potential crash when deriving the hardware platform string on iOS-family and watchOS by making `getPlatformString()` return optional, guarding `sysctl` return codes/size, and allocating an extra byte to ensure NUL termination.
> 
> When the platform string can’t be retrieved, device model resolution now falls back to `"unknown"` instead of assuming `sysctl` succeeded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5c82ed13d638e6e7de5b035db7ff5bf07e03007. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->