### PR TITLE
fix: restore deleted parameter to maintain api stability

### DIFF
--- a/Sources/AmplitudeCore/Diagnostics/DiagnosticsClient.swift
+++ b/Sources/AmplitudeCore/Diagnostics/DiagnosticsClient.swift
@@ -50,6 +50,7 @@ public actor DiagnosticsClient: CoreDiagnostics {
                 logger: CoreLogger = OSLogger(logLevel: .error),
                 enabled: Bool = true,
                 sampleRate: Double = DEFAULT_SAMPLE_RATE,
+                crashCaptureEnabled: Bool = false, // unused, but removal is a breaking change.
                 remoteConfigClient: RemoteConfigClient?,
                 flushIntervalNanoSec: UInt64 = DEFAULT_FLUSH_INTERVAL * NSEC_PER_SEC,
                 urlSessionConfiguration: URLSessionConfiguration = .ephemeral) {


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Restores deleted parameter in https://github.com/amplitude/AmplitudeCore-Swift/pull/59 to maintain API compatibility and fix a crash on SR init.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Signature-only compatibility fix with no behavioral changes; risk is limited to potential confusion from an unused parameter.
> 
> **Overview**
> Restores the `crashCaptureEnabled` parameter on `DiagnosticsClient`’s initializer (defaulting to `false`) to preserve source compatibility for callers after it was previously removed. The parameter is currently unused, but prevents client compile/runtime issues caused by the signature change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1343e7341c04ee410c31832342caf4074b5f9bed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->