### PR TITLE
fix: remove RemoteConfigClient weak task capture that leaks on init

### DIFF
--- a/Sources/AmplitudeCore/Remote Config/RemoteConfigClient.swift
+++ b/Sources/AmplitudeCore/Remote Config/RemoteConfigClient.swift
@@ -136,12 +136,13 @@ public actor RemoteConfigClient: NSObject {
 
         super.init()
 
-        fetchRemoteTask = Task.detached { [urlSession, serverUrl, apiKey, maxRetryDelay, weak self] in
+        fetchRemoteTask = Task.detached { [urlSession, serverUrl, apiKey, maxRetryDelay, storage] in
             let config = try await Self.fetch(urlSession: urlSession,
                                               serverUrl: serverUrl,
                                               apiKey: apiKey,
                                               maxRetryDelay: maxRetryDelay)
-            try? await self?.storage.setConfig(config)
+            try Task.checkCancellation()
+            try? await storage.setConfig(config)
             return config
         }
     }
@@ -301,12 +302,14 @@ public actor RemoteConfigClient: NSObject {
 
     @discardableResult
     private func _updateConfigs() -> Task<RemoteConfigInfo, Error> {
-        fetchRemoteTask = Task.detached { [urlSession, serverUrl, apiKey, maxRetryDelay, weak self] in
+        let storage = self.storage
+        fetchRemoteTask = Task.detached { [urlSession, serverUrl, apiKey, maxRetryDelay, storage] in
             let config = try await Self.fetch(urlSession: urlSession,
                                               serverUrl: serverUrl,
                                               apiKey: apiKey,
                                               maxRetryDelay: maxRetryDelay)
-            try? await self?.storage.setConfig(config)
+            try Task.checkCancellation()
+            try? await storage.setConfig(config)
             return config
         }
         return fetchRemoteTask


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->
fix https://github.com/amplitude/AmplitudeCore-Swift/issues/57

### Summary

Fix a 32-byte memory leak during SDK initialization in `RemoteConfigClient`.

`RemoteConfigClient.init` and `_updateConfigs()` used `[weak self]` in their `Task.detached` closures, but self was only needed to access `self.storage`. The `[weak self]` capture triggers `swift_weakInit`, which allocates a 32-byte side table entry in the Swift runtime. This side table persists for the lifetime of the `RemoteConfigClient` object and is flagged as a leak by Instruments because its conservative memory scanner cannot trace Swift's internal tagged-pointer encoding in the object's refcount field.

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only how `Task.detached` closures capture `storage` and adds a cancellation check before caching, with minimal impact to remote config fetching behavior.
> 
> **Overview**
> Fixes a memory leak during `RemoteConfigClient` initialization and refresh by removing `[weak self]` from detached remote-fetch tasks and capturing `storage` directly.
> 
> Also adds `Task.checkCancellation()` before persisting fetched configs so cancelled fetches don’t write to cache.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 990d06ea6d287b3f92ef846f4852af5c3ebc9578. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->