### PR TITLE
chore: SECENG-7706 [security] Pin versions of GitHub Actions to full commit hash

### DIFF
--- a/.github/workflows/jira-issue-create.yml
+++ b/.github/workflows/jira-issue-create.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   call-workflow-passing-data:
-    uses: amplitude/Amplitude-TypeScript/.github/workflows/jira-issue-create-template.yml@main
+    uses: amplitude/Amplitude-TypeScript/.github/workflows/jira-issue-create-template.yml@c832303a64c05b9911b6b1ad3dd8f69099f71179 # @amplitude/analytics-browser@2.36.9
     with:
       label: "Swift"
       subcomponent: "dx_ios_sdk_(swift)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: ${{ github.actor }} permission check to do a release
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@02f5e7c637a73a3b12ed81015fa7fb5f11cc5d7d # v2.x
         with:
           route: GET /repos/:repository/collaborators/${{ github.actor }}
           repository: ${{ github.repository }}
@@ -31,7 +31,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
         # Use a modern version of xcode to compile build tools
         # See https://github.com/swiftlang/swift-package-manager/issues/4651
@@ -50,7 +50,7 @@ jobs:
           sudo xcodebuild -downloadPlatform visionOS
 
       - name: Checkout swift-create-xcframework
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: segment-integrations/swift-create-xcframework
           path: swift-create-xcframework
@@ -60,7 +60,7 @@ jobs:
         run: echo "cache_key=$(xcodebuild -version | head -n 1 | tr -d ' ')-$(git -C swift-create-xcframework rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Restore swift-create-xcframework Build cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: swift-create-xcframework/.build
           key: ${{ runner.os }}-build-${{ steps.compute-cache-key.outputs.cache_key }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -41,7 +41,7 @@ jobs:
             device: "Apple Vision Pro"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Set Xcode ${{ matrix.xcode }}
         run: |
           sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app


### PR DESCRIPTION
This PR pins versions of GitHub Actions to full commit hash via automated scripts.
In general, this PR doesn't change the behavior of the workflows, so you can merge this safely.

This pull request was created by [multi-gitter](https://github.com/lindell/multi-gitter).

Please merge this pull request by 2026-04-10.

For any questions, please ask in the Slack channel #help-security.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low functional risk since this only pins action references, but it can break CI/release if any pinned SHA is incorrect or later removed upstream.
> 
> **Overview**
> Pins GitHub Actions/reusable workflow references in CI workflows to full commit SHAs instead of floating tags/branches.
> 
> This updates `jira-issue-create.yml`, `release.yml`, and `unit-test.yml` to use immutable SHAs for `actions/checkout`, `actions/cache`, `octokit/request-action`, and the external `jira-issue-create-template` workflow, improving supply-chain security and reproducibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d68f3b8e5df2963dff5fb099d302a35b32c621a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->