### PR TITLE
fix: waitForRemote subscribers should receive subsequent config updates

### DIFF
--- a/Sources/AmplitudeCore/Remote Config/RemoteConfigClient.swift
+++ b/Sources/AmplitudeCore/Remote Config/RemoteConfigClient.swift
@@ -288,7 +288,7 @@ public actor RemoteConfigClient: NSObject {
                         break
                     case .waitForRemote:
                         // Wait until the initial callback from subscribe is fired
-                        guard callback.lastCallbackTime == nil else {
+                        guard callback.lastCallbackTime != nil else {
                             continue
                         }
                     }

--- a/Tests/AmplitudeCoreTests/RemoteConfigTests.swift
+++ b/Tests/AmplitudeCoreTests/RemoteConfigTests.swift
@@ -326,6 +326,40 @@ final class RemoteConfigTests: XCTestCase {
     }
 
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func testWaitForRemoteDeliveryStrategyReceivesSubsequentUpdates() async throws {
+        TestRemoteConfigHandler.responseHandler = TestRemoteConfigHandler.errorResponseHandler(statusCode: 400)
+
+        let remoteConfig: RemoteConfigClient.RemoteConfig = ["remote": 1]
+        let remoteConfigClient = makeRemoteConfigClient()
+
+        let didReceiveInitialResponseExpectation = XCTestExpectation(description: "it receives initial remote failure")
+        didReceiveInitialResponseExpectation.assertForOverFulfill = true
+
+        let didReceiveUpdateExpectation = XCTestExpectation(description: "it receives subsequent remote update")
+        didReceiveUpdateExpectation.assertForOverFulfill = true
+
+        remoteConfigClient.subscribe(deliveryMode: .waitForRemote()) { config, source, lastFetch in
+            XCTAssertEqual(source, .remote)
+
+            if let config {
+                XCTAssertEqual(config as NSDictionary, remoteConfig as NSDictionary)
+                XCTAssertNotNil(lastFetch)
+                didReceiveUpdateExpectation.fulfill()
+            } else {
+                XCTAssertNil(lastFetch)
+                didReceiveInitialResponseExpectation.fulfill()
+            }
+        }
+
+        await fulfillment(of: [didReceiveInitialResponseExpectation], timeout: 3)
+
+        TestRemoteConfigHandler.responseHandler = TestRemoteConfigHandler.successResponseHandler(remoteConfig)
+        remoteConfigClient.updateConfigs()
+
+        await fulfillment(of: [didReceiveUpdateExpectation], timeout: 3)
+    }
+
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func testWaitForRemoteDeliveryStrategyTimeout() async throws {
         let didSendRemoteRequestExpectation = XCTestExpectation(description: "it did request config")
         TestRemoteConfigHandler.responseHandler = { request in


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

WaitForRemote subscribers should receive subsequent updates.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line logic fix in remote config callback dispatch with targeted test coverage; behavior change only affects `waitForRemote` subscribers on manual refresh.
> 
> **Overview**
> Fixes **`.waitForRemote`** subscribers missing config pushed by **`updateConfigs()`** after their first callback.
> 
> In **`RemoteConfigClient.updateConfigs()`**, the guard on **`lastCallbackTime`** was inverted: it skipped subscribers who had already received the initial subscribe callback and only notified those who had not. The condition is flipped to **`!= nil`** so later remote refreshes are sent only after the initial **`waitForRemote`** delivery completes (still skipping subscribers that have not fired once yet).
> 
> Adds **`testWaitForRemoteDeliveryStrategyReceivesSubsequentUpdates`**, which asserts an initial remote failure callback then a successful config after **`updateConfigs()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19ea97729e51bba04fc83c3a36775b53e5f281ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->