### PR TITLE
fix: remove Xcode toolchain rpath from xcframework that breaks app notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,12 +107,15 @@ jobs:
           tmp="$(mktemp -d)"
           unzip -qo AmplitudeCore.zip -d "$tmp"
           unzip -qo AmplitudeCoreNoUIKit.zip -d "$tmp"
-          bad="$(find "$tmp" -type f -path '*.framework/*' | while read -r b; do
-            file "$b" | grep -q Mach-O || continue
-            otool -l "$b" | grep -q '\.xctoolchain' && echo "$b"
-          done)"
-          if [ -n "$bad" ]; then
-            echo "::error::toolchain rpath still present in:"; echo "$bad"; exit 1
+          found=0
+          while IFS= read -r b; do
+            if file "$b" | grep -q Mach-O && otool -l "$b" | grep -q '\.xctoolchain'; then
+              echo "::error::toolchain rpath still present in $b"
+              found=1
+            fi
+          done < <(find "$tmp" -type f -path '*.framework/*')
+          if [ "$found" -ne 0 ]; then
+            exit 1
           fi
           echo "OK: no .xctoolchain rpath in any AmplitudeCore xcframework slice"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,12 +108,20 @@ jobs:
           unzip -qo AmplitudeCore.zip -d "$tmp"
           unzip -qo AmplitudeCoreNoUIKit.zip -d "$tmp"
           found=0
+          inspected=0
           while IFS= read -r b; do
-            if file "$b" | grep -q Mach-O && otool -l "$b" | grep -q '\.xctoolchain'; then
-              echo "::error::toolchain rpath still present in $b"
-              found=1
+            if file "$b" | grep -q Mach-O; then
+              inspected=$((inspected + 1))
+              if otool -l "$b" | grep -q '\.xctoolchain'; then
+                echo "::error::toolchain rpath still present in $b"
+                found=1
+              fi
             fi
           done < <(find "$tmp" -type f -path '*.framework/*')
+          if [ "$inspected" -eq 0 ]; then
+            echo "::error::no Mach-O binaries found in AmplitudeCore xcframework slices"
+            exit 1
+          fi
           if [ "$found" -ne 0 ]; then
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,7 @@ jobs:
           --skip-binary-targets \
           --stack-evolution \
           --xc-setting DEFINES_MODULE=1 \
+          --xc-setting "LD_RUNPATH_SEARCH_PATHS=@executable_path/Frameworks @loader_path/Frameworks /usr/lib/swift" \
           --zip
 
       - name: Build Framework No UIKit
@@ -97,7 +98,23 @@ jobs:
           --stack-evolution \
           --xc-setting DEFINES_MODULE=1 \
           --xc-setting AMPLITUDE_DISABLE_UIKIT=1 \
+          --xc-setting "LD_RUNPATH_SEARCH_PATHS=@executable_path/Frameworks @loader_path/Frameworks /usr/lib/swift" \
           --zip
+
+      - name: Assert no toolchain rpath in xcframeworks
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          unzip -qo AmplitudeCore.zip -d "$tmp"
+          unzip -qo AmplitudeCoreNoUIKit.zip -d "$tmp"
+          bad="$(find "$tmp" -type f -path '*.framework/*' | while read -r b; do
+            file "$b" | grep -q Mach-O || continue
+            otool -l "$b" | grep -q '\.xctoolchain' && echo "$b"
+          done)"
+          if [ -n "$bad" ]; then
+            echo "::error::toolchain rpath still present in:"; echo "$bad"; exit 1
+          fi
+          echo "OK: no .xctoolchain rpath in any AmplitudeCore xcframework slice"
 
       - name: Validate Podfile
         run: |


### PR DESCRIPTION
Release builds baked the build host's Xcode toolchain path into `LD_RUNPATH_SEARCH_PATHS` of the shipped `AmplitudeCore.framework`. On the x86_64 macOS slice (libswiftCore loaded via `@rpath`), notarization resolves `@rpath/libswiftCore.dylib` against the dead toolchain path → Fatal "Bad Load Command", quarantining host apps (Camtasia, macOS 15).

**Fix:** override `LD_RUNPATH_SEARCH_PATHS` on the `xcodebuild` command line for both xcframework builds (`@executable_path/Frameworks @loader_path/Frameworks /usr/lib/swift`); `/usr/lib/swift` keeps libswiftCore resolvable on ABI-stable OSes. Adds a CI assertion that fails the release if any slice keeps an `.xctoolchain` rpath. No deployment-target change.

**Validated** via dry-run on Xcode 16.3: assertion green across all AmplitudeCore + AmplitudeCoreNoUIKit slices.

Refs amplitude/Amplitude-Swift#405 (SDKI-6) · companion: amplitude/Amplitude-Swift#406

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only affect release packaging/link settings for distributed binaries; incorrect runpaths could break Swift runtime loading on some platforms, but scope is limited to CI xcframework builds plus a guard assertion.
> 
> **Overview**
> Release xcframework builds now pass an explicit **`LD_RUNPATH_SEARCH_PATHS`** override (`@executable_path/Frameworks`, `@loader_path/Frameworks`, `/usr/lib/swift`) for both **AmplitudeCore** and **AmplitudeCoreNoUIKit**, so shipped binaries no longer embed the CI host’s **`.xctoolchain`** path in runpaths (which broke macOS notarization when resolving `@rpath/libswiftCore.dylib`).
> 
> A new **release workflow** step unpacks both zips, scans Mach-O slices under each framework with **`otool`**, and **fails the job** if any slice still references `.xctoolchain`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc39b3ed07589b7e3c75076f70c6176fe16f7eb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->