### PR TITLE
fix(internal): make didLastRunCrash readable synchronously without a client

### DIFF
--- a/Sources/AmplitudeCore/Diagnostics/DiagnosticsClient.swift
+++ b/Sources/AmplitudeCore/Diagnostics/DiagnosticsClient.swift
@@ -108,6 +108,17 @@ public actor DiagnosticsClient: CoreDiagnostics {
         }
     }
 
+    /// Synchronously reports whether the previous app run ended in a crash.
+    ///
+    /// Unlike the async instance property, this needs **no initialized client and no `await`**:
+    /// it reads a lock-guarded static that self-materializes from disk. Use it to gate setup
+    /// that must run *before* any Amplitude SDK is initialized (e.g. closing open guides/surveys
+    /// after a prior crash). As a `static` member of an `actor` it is not actor-isolated, so it
+    /// is safe to read from any synchronous context.
+    public static var didLastRunCrash: Bool {
+        CrashCatcher.didLastRunCrash
+    }
+
     public func setTag(name: String, value: String) async {
         await storage.setTag(name: name, value: value)
     }

--- a/Tests/AmplitudeCoreTests/DiagnosticsClientTests.swift
+++ b/Tests/AmplitudeCoreTests/DiagnosticsClientTests.swift
@@ -1126,6 +1126,33 @@ final class DiagnosticsClientTests: XCTestCase {
         XCTAssertEqual(crashEvents1.count + crashEvents2.count, 1, "Crash event should be recorded by exactly one client")
     }
 
+    // MARK: - Synchronous Crash Accessor Tests
+
+    func testStaticDidLastRunCrash_noCrashFile_returnsFalse() {
+        // No await, no DiagnosticsClient instance — this is the G+S pre-init call shape.
+        XCTAssertFalse(DiagnosticsClient.didLastRunCrash)
+    }
+
+    func testStaticDidLastRunCrash_withCrashFile_returnsTrue() {
+        CrashCatcher.writeFakeCrashReport("Fatal Signal: SIGSEGV (11)")
+
+        // Read synchronously without instantiating a client.
+        XCTAssertTrue(DiagnosticsClient.didLastRunCrash)
+    }
+
+    func testStaticDidLastRunCrash_matchesInstanceAsyncProperty() async {
+        CrashCatcher.writeFakeCrashReport("Fatal Signal: SIGABRT (6)")
+
+        let syncValue = DiagnosticsClient.didLastRunCrash
+
+        let client = makeDiagnosticsClient()
+        await client.initializationTask?.value
+        let asyncValue = await client.didLastRunCrash
+
+        XCTAssertTrue(syncValue)
+        XCTAssertEqual(syncValue, asyncValue, "Static sync accessor must agree with the instance async property")
+    }
+
     // MARK: - Util
 
     private func makeDiagnosticsClient(instanceName: String? = nil) -> DiagnosticsClient {


### PR DESCRIPTION
### Summary

The only way to read "did the last run crash" right now is async + actor-isolated
(`CoreDiagnostics.didLastRunCrash`, the instance property, and the callback variant —
all of them need an already-initialized DiagnosticsClient).

Jared wants to use this in the G+S mobile SDK to close any open guides/surveys if the
last run crashed, *before* the library initializes. Their init path is all synchronous,
so an async property would force a big change on their side.

The data is already sync — `CrashCatcher.didLastRunCrash` is a lock-guarded static that
reads from disk, no actor or client needed. The async was just an actor-isolation
artifact. So this adds a `static` accessor on DiagnosticsClient (statics on an actor
aren't isolated, so it reads with no `await` and no instance):

```swift
if DiagnosticsClient.didLastRunCrash {
    closeOpenGuidesAndSurveys()
}
initializeGuidesAndSurveys()
```

Additive only — the async property, callback variant, and protocol are untouched, and
CrashCatcher stays internal. No Package.swift changes.

Added tests for the no-crash / crash cases and that the sync value matches the existing
async one.

### Checklist

* [x] Does your PR title have the correct title format?
* Does your PR have a breaking change?: No

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API that re-exposes existing crash-state logic; no changes to async diagnostics or crash reporting behavior.
> 
> **Overview**
> Adds **`DiagnosticsClient.didLastRunCrash`** as a **public static** property so callers can read whether the previous run crashed **without** creating a `DiagnosticsClient` or using `await`. It forwards to the existing lock-guarded `CrashCatcher` disk read, aimed at pre-SDK-init flows (e.g. closing guides/surveys after a crash).
> 
> The existing **async instance** `didLastRunCrash`, `CoreDiagnostics`, and callback helper are unchanged. New unit tests cover no-crash/crash cases and parity with the async property.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40259ed86fca6e1db8d17a7bef623ac28b654b65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->