### PR TITLE
fix(diagnostics): tag sessions with app distribution environment

### DIFF
--- a/Sources/AmplitudeCore/Diagnostics/DiagnosticsClient.swift
+++ b/Sources/AmplitudeCore/Diagnostics/DiagnosticsClient.swift
@@ -313,12 +313,13 @@ public actor DiagnosticsClient: CoreDiagnostics {
         staticContext["os_name"] = await device.os_name
         staticContext["os_version"] = await device.os_version
         staticContext["platform"] = await device.platform
-        // Distribution channel (appstore / testflight / development / simulator),
-        // so aggregates can be filtered to production traffic. Observability
-        // first: once the tag proves reliable in the field, sampling will be
-        // gated to App Store installs (SDKI-14). Named "app.environment" to stay
-        // clear of the org-wide "environment" (deploy env) tag key.
+        // Distribution channel (best-effort heuristics, observability) and
+        // release-build flag (deterministic), so aggregates can be filtered to
+        // production traffic. Once the tags prove reliable in the field,
+        // sampling will be gated on release builds (SDKI-14). Named "app.*" to
+        // stay clear of the org-wide "environment" (deploy env) tag key.
         staticContext["app.environment"] = AppEnvironment.current.rawValue
+        staticContext["app.release"] = AppEnvironment.isReleaseBuild ? "true" : "false"
 
         staticContext["sdk.\(AmplitudeContext.coreLibraryName).version"] = AmplitudeContext.coreLibraryVersion
 

--- a/Sources/AmplitudeCore/Diagnostics/DiagnosticsClient.swift
+++ b/Sources/AmplitudeCore/Diagnostics/DiagnosticsClient.swift
@@ -153,6 +153,9 @@ public actor DiagnosticsClient: CoreDiagnostics {
     }
 
     public func flush() async {
+        // Ensure the basic tags (device, environment, …) have landed in storage
+        // before dumping, so early flushes never upload untagged snapshots.
+        await basicTagsTask?.value
         guard shouldTrack, let snapshot = await storage.dumpAndClearCurrentSession() else { return }
         await uploadSnapshot(snapshot)
     }
@@ -310,6 +313,12 @@ public actor DiagnosticsClient: CoreDiagnostics {
         staticContext["os_name"] = await device.os_name
         staticContext["os_version"] = await device.os_version
         staticContext["platform"] = await device.platform
+        // Distribution channel (appstore / testflight / development / simulator),
+        // so aggregates can be filtered to production traffic. Observability
+        // first: once the tag proves reliable in the field, sampling will be
+        // gated to App Store installs (SDKI-14). Named "app.environment" to stay
+        // clear of the org-wide "environment" (deploy env) tag key.
+        staticContext["app.environment"] = AppEnvironment.current.rawValue
 
         staticContext["sdk.\(AmplitudeContext.coreLibraryName).version"] = AmplitudeContext.coreLibraryVersion
 

--- a/Sources/AmplitudeCore/Utilities/AppEnvironment.swift
+++ b/Sources/AmplitudeCore/Utilities/AppEnvironment.swift
@@ -34,6 +34,41 @@ enum AppEnvironment: String, Sendable {
         overrideForTesting ?? detected
     }
 
+    /// Test hook: when set, `isReleaseBuild` returns this value instead of the detected one.
+    nonisolated(unsafe) static var releaseBuildOverrideForTesting: Bool?
+
+    /// Whether the host app is a release (non-debuggable) build.
+    ///
+    /// Unlike the distribution channel above — which relies on best-effort store
+    /// heuristics — this is deterministic: debuggable builds are marked by the
+    /// get-task-allow entitlement (macOS) or a development provisioning profile
+    /// carrying it (iOS family), and source-integrated SDK builds compile with
+    /// the host app's configuration. Guard-phase sampling (SDKI-14) will trust
+    /// all release builds.
+    static var isReleaseBuild: Bool {
+        releaseBuildOverrideForTesting ?? detectedReleaseBuild
+    }
+
+    private static let detectedReleaseBuild: Bool = {
+#if DEBUG
+        // Source integration (SPM/CocoaPods) compiles the SDK with the host
+        // app's build configuration; a debug host means a debug SDK.
+        return false
+#elseif targetEnvironment(simulator)
+        return false
+#elseif os(macOS) || targetEnvironment(macCatalyst)
+        return !isDebuggableBuild
+#else
+        // Development installs embed a provisioning profile whose entitlements
+        // carry get-task-allow=true (required for attaching a debugger). Store
+        // installs embed no profile; ad-hoc/enterprise profiles carry false.
+        guard let entitlements = embeddedProvisioningEntitlements() else {
+            return true
+        }
+        return (entitlements["get-task-allow"] as? Bool) != true
+#endif
+    }()
+
     private static let detected: AppEnvironment = {
 #if targetEnvironment(simulator)
         return .simulator
@@ -102,6 +137,30 @@ enum AppEnvironment: String, Sendable {
         return summary.hasPrefix("Developer ID Application")
     }
 #endif
+
+    /// Entitlements embedded in the host app's provisioning profile, or nil
+    /// when no profile is embedded (store installs).
+    private static func embeddedProvisioningEntitlements() -> [String: Any]? {
+        guard let path = mainAppBundle.path(forResource: "embedded", ofType: "mobileprovision"),
+              let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
+            return nil
+        }
+        return provisioningEntitlements(in: data)
+    }
+
+    /// Extracts the `Entitlements` dictionary from a provisioning profile blob —
+    /// a CMS envelope wrapping an XML plist.
+    static func provisioningEntitlements(in data: Data) -> [String: Any]? {
+        guard let start = data.range(of: Data("<?xml".utf8)),
+              let end = data.range(of: Data("</plist>".utf8), in: start.lowerBound..<data.endIndex) else {
+            return nil
+        }
+        let plistData = data.subdata(in: start.lowerBound..<end.upperBound)
+        guard let plist = try? PropertyListSerialization.propertyList(from: plistData, options: [], format: nil) as? [String: Any] else {
+            return nil
+        }
+        return plist["Entitlements"] as? [String: Any]
+    }
 
     /// `Bundle.main`, except inside an app extension (`.appex`), where receipts
     /// and provisioning profiles live in the containing app's bundle instead.

--- a/Sources/AmplitudeCore/Utilities/AppEnvironment.swift
+++ b/Sources/AmplitudeCore/Utilities/AppEnvironment.swift
@@ -6,17 +6,24 @@
 //
 
 import Foundation
+#if os(macOS) || targetEnvironment(macCatalyst)
+import Security
+#endif
 
 /// Distribution channel of the host app.
 ///
 /// Diagnostics tags every session with this value: simulator, development, and
 /// TestFlight runs routinely exercise stress scenarios and debug tooling whose
 /// outliers dominate max-type aggregates and skew guard-threshold calibration,
-/// so aggregates need to be filterable to production traffic. Once the tag
-/// proves reliable in the field, sampling will be gated on `.appStore` (SDKI-14).
+/// so aggregates need to be filterable to production traffic. Production
+/// channels are `appStore` and (on macOS) `developerID`. Once the tag proves
+/// reliable in the field, sampling will be gated on them (SDKI-14).
 enum AppEnvironment: String, Sendable {
     case appStore = "appstore"
     case testFlight = "testflight"
+    /// Direct distribution signed with a Developer ID certificate (macOS only) —
+    /// production end-user traffic, just not store-verified.
+    case developerID = "developerid"
     case development = "development"
     case simulator = "simulator"
 
@@ -30,10 +37,27 @@ enum AppEnvironment: String, Sendable {
     private static let detected: AppEnvironment = {
 #if targetEnvironment(simulator)
         return .simulator
+#elseif os(macOS) || targetEnvironment(macCatalyst)
+        // Debuggable (Xcode-run / development-exported) builds carry the
+        // get-task-allow entitlement regardless of signing identity.
+        if isDebuggableBuild {
+            return .development
+        }
+        // Store installs carry a receipt file (the host app's, for extensions).
+        // Mac receipts keep the production filename even for TestFlight, but the
+        // receipt payload embeds the environment as a plain string.
+        if let receiptURL = mainAppBundle.appStoreReceiptURL,
+           let receipt = try? Data(contentsOf: receiptURL) {
+            return receipt.range(of: Data("ProductionSandbox".utf8)) != nil ? .testFlight : .appStore
+        }
+        // Direct distribution signed with a Developer ID certificate is
+        // production traffic; everything else stays conservative.
+        return isDeveloperIDSigned ? .developerID : .development
 #else
-        // Extensions check the containing app's bundle.
-        let bundle = mainAppBundle
-        if hasEmbeddedProvisioningProfile(bundle) {
+        // Development / ad-hoc / enterprise builds embed a provisioning profile;
+        // App Store and TestFlight installs do not. Extensions check the
+        // containing app's bundle.
+        if mainAppBundle.path(forResource: "embedded", ofType: "mobileprovision") != nil {
             return .development
         }
         // TestFlight (and other sandbox) installs use a sandbox receipt — same
@@ -41,36 +65,43 @@ enum AppEnvironment: String, Sendable {
         // process's bundle (receipt name derived from the install environment)
         // and the resolved host app bundle (bundle-relative receipt path), since
         // in app extensions either one may carry the sandbox naming.
-        if [Bundle.main, bundle].contains(where: { $0.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt" }) {
+        if [Bundle.main, mainAppBundle].contains(where: { $0.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt" }) {
             return .testFlight
         }
-#if os(macOS) || targetEnvironment(macCatalyst)
-        // Dev-run Mac apps carry neither a provisioning profile nor a receipt,
-        // so additionally require a real store receipt (the host app's, for
-        // extensions) before trusting App Store. iOS-family devices skip this:
-        // every non-store install there carries a provisioning profile, and the
-        // receipt file's presence should not be load-bearing.
-        guard let receiptURL = bundle.appStoreReceiptURL,
-              FileManager.default.fileExists(atPath: receiptURL.path) else {
-            return .development
-        }
-#endif
         return .appStore
 #endif
     }()
 
-    /// Development / ad-hoc / enterprise builds embed a provisioning profile;
-    /// App Store and TestFlight installs do not.
-    private static func hasEmbeddedProvisioningProfile(_ bundle: Bundle) -> Bool {
 #if os(macOS) || targetEnvironment(macCatalyst)
-        // Mac bundles keep the profile at Contents/embedded.provisionprofile,
-        // outside the Resources directory that path(forResource:) searches.
-        let url = bundle.bundleURL.appendingPathComponent("Contents/embedded.provisionprofile")
-        return FileManager.default.fileExists(atPath: url.path)
-#else
-        return bundle.path(forResource: "embedded", ofType: "mobileprovision") != nil
-#endif
+    /// Whether the current process carries the `get-task-allow` entitlement —
+    /// true for Xcode-run and development-exported builds, false for App Store,
+    /// TestFlight, and Developer ID distribution.
+    private static var isDebuggableBuild: Bool {
+        guard let task = SecTaskCreateFromSelf(nil),
+              let value = SecTaskCopyValueForEntitlement(task, "get-task-allow" as CFString, nil) else {
+            return false
+        }
+        return (value as? NSNumber)?.boolValue == true
     }
+
+    /// Whether the current process's code signature chains to a
+    /// "Developer ID Application" leaf certificate (direct distribution).
+    private static var isDeveloperIDSigned: Bool {
+        var code: SecCode?
+        guard SecCodeCopySelf([], &code) == errSecSuccess, let code else { return false }
+        var staticCode: SecStaticCode?
+        guard SecCodeCopyStaticCode(code, [], &staticCode) == errSecSuccess, let staticCode else { return false }
+        var infoCF: CFDictionary?
+        guard SecCodeCopySigningInformation(staticCode, SecCSFlags(rawValue: kSecCSSigningInformation), &infoCF) == errSecSuccess,
+              let info = infoCF as? [String: Any],
+              let certificates = info[kSecCodeInfoCertificates as String] as? [SecCertificate],
+              let leaf = certificates.first,
+              let summary = SecCertificateCopySubjectSummary(leaf) as String? else {
+            return false
+        }
+        return summary.hasPrefix("Developer ID Application")
+    }
+#endif
 
     /// `Bundle.main`, except inside an app extension (`.appex`), where receipts
     /// and provisioning profiles live in the containing app's bundle instead.

--- a/Sources/AmplitudeCore/Utilities/AppEnvironment.swift
+++ b/Sources/AmplitudeCore/Utilities/AppEnvironment.swift
@@ -36,11 +36,12 @@ enum AppEnvironment: String, Sendable {
         if hasEmbeddedProvisioningProfile(bundle) {
             return .development
         }
-        // TestFlight (and other sandbox) installs use a sandbox receipt. The
-        // receipt URL's name is derived from the current process's install
-        // environment, so check `Bundle.main` directly — same technique as
-        // Firebase's GULAppEnvironmentUtil.
-        if Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt" {
+        // TestFlight (and other sandbox) installs use a sandbox receipt — same
+        // technique as Firebase's GULAppEnvironmentUtil. Check both the current
+        // process's bundle (receipt name derived from the install environment)
+        // and the resolved host app bundle (bundle-relative receipt path), since
+        // in app extensions either one may carry the sandbox naming.
+        if [Bundle.main, bundle].contains(where: { $0.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt" }) {
             return .testFlight
         }
 #if os(macOS) || targetEnvironment(macCatalyst)

--- a/Sources/AmplitudeCore/Utilities/AppEnvironment.swift
+++ b/Sources/AmplitudeCore/Utilities/AppEnvironment.swift
@@ -1,0 +1,99 @@
+//
+//  AppEnvironment.swift
+//  AmplitudeCore
+//
+//  Created by Jin Xu on 07/23/26.
+//
+
+import Foundation
+
+/// Distribution channel of the host app.
+///
+/// Diagnostics tags every session with this value: simulator, development, and
+/// TestFlight runs routinely exercise stress scenarios and debug tooling whose
+/// outliers dominate max-type aggregates and skew guard-threshold calibration,
+/// so aggregates need to be filterable to production traffic. Once the tag
+/// proves reliable in the field, sampling will be gated on `.appStore` (SDKI-14).
+enum AppEnvironment: String, Sendable {
+    case appStore = "appstore"
+    case testFlight = "testflight"
+    case development = "development"
+    case simulator = "simulator"
+
+    /// Test hook: when set, `current` returns this value instead of the detected one.
+    nonisolated(unsafe) static var overrideForTesting: AppEnvironment?
+
+    static var current: AppEnvironment {
+        overrideForTesting ?? detected
+    }
+
+    private static let detected: AppEnvironment = {
+#if targetEnvironment(simulator)
+        return .simulator
+#else
+        // Extensions check the containing app's bundle.
+        let bundle = mainAppBundle
+        if hasEmbeddedProvisioningProfile(bundle) {
+            return .development
+        }
+        // TestFlight (and other sandbox) installs use a sandbox receipt. The
+        // receipt URL's name is derived from the current process's install
+        // environment, so check `Bundle.main` directly — same technique as
+        // Firebase's GULAppEnvironmentUtil.
+        if Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt" {
+            return .testFlight
+        }
+#if os(macOS) || targetEnvironment(macCatalyst)
+        // Dev-run Mac apps carry neither a provisioning profile nor a receipt,
+        // so additionally require a real store receipt (the host app's, for
+        // extensions) before trusting App Store. iOS-family devices skip this:
+        // every non-store install there carries a provisioning profile, and the
+        // receipt file's presence should not be load-bearing.
+        guard let receiptURL = bundle.appStoreReceiptURL,
+              FileManager.default.fileExists(atPath: receiptURL.path) else {
+            return .development
+        }
+#endif
+        return .appStore
+#endif
+    }()
+
+    /// Development / ad-hoc / enterprise builds embed a provisioning profile;
+    /// App Store and TestFlight installs do not.
+    private static func hasEmbeddedProvisioningProfile(_ bundle: Bundle) -> Bool {
+#if os(macOS) || targetEnvironment(macCatalyst)
+        // Mac bundles keep the profile at Contents/embedded.provisionprofile,
+        // outside the Resources directory that path(forResource:) searches.
+        let url = bundle.bundleURL.appendingPathComponent("Contents/embedded.provisionprofile")
+        return FileManager.default.fileExists(atPath: url.path)
+#else
+        return bundle.path(forResource: "embedded", ofType: "mobileprovision") != nil
+#endif
+    }
+
+    /// `Bundle.main`, except inside an app extension (`.appex`), where receipts
+    /// and provisioning profiles live in the containing app's bundle instead.
+    /// Falls back to `Bundle.main` when the containing app cannot be resolved.
+    private static var mainAppBundle: Bundle {
+        let main = Bundle.main
+        guard let hostURL = containingAppBundleURL(of: main.bundleURL),
+              let host = Bundle(url: hostURL) else {
+            return main
+        }
+        return host
+    }
+
+    /// Resolves the containing `.app` bundle URL for an app-extension bundle URL.
+    /// Returns nil when the URL is not an extension or no enclosing app exists.
+    static func containingAppBundleURL(of bundleURL: URL) -> URL? {
+        guard bundleURL.pathExtension == "appex" else { return nil }
+        var url = bundleURL.deletingLastPathComponent()
+        while !url.path.isEmpty && url.path != "/" {
+            if url.pathExtension == "app" {
+                return url
+            }
+            url = url.deletingLastPathComponent()
+        }
+        return nil
+    }
+}

--- a/Tests/AmplitudeCoreTests/AppEnvironmentTests.swift
+++ b/Tests/AmplitudeCoreTests/AppEnvironmentTests.swift
@@ -50,6 +50,7 @@ final class AppEnvironmentTests: XCTestCase {
     func testEnvironmentTagValues() {
         XCTAssertEqual(AppEnvironment.appStore.rawValue, "appstore")
         XCTAssertEqual(AppEnvironment.testFlight.rawValue, "testflight")
+        XCTAssertEqual(AppEnvironment.developerID.rawValue, "developerid")
         XCTAssertEqual(AppEnvironment.development.rawValue, "development")
         XCTAssertEqual(AppEnvironment.simulator.rawValue, "simulator")
     }

--- a/Tests/AmplitudeCoreTests/AppEnvironmentTests.swift
+++ b/Tests/AmplitudeCoreTests/AppEnvironmentTests.swift
@@ -13,6 +13,7 @@ final class AppEnvironmentTests: XCTestCase {
 
     override func tearDown() {
         AppEnvironment.overrideForTesting = nil
+        AppEnvironment.releaseBuildOverrideForTesting = nil
         super.tearDown()
     }
 
@@ -57,6 +58,7 @@ final class AppEnvironmentTests: XCTestCase {
 
     func testEnvironmentTagIsSetOnDiagnostics() async {
         AppEnvironment.overrideForTesting = .testFlight
+        AppEnvironment.releaseBuildOverrideForTesting = true
         let client = DiagnosticsClient(
             apiKey: "test-app-environment-key",
             instanceName: "test-app-environment-\(UUID().uuidString)",
@@ -64,9 +66,43 @@ final class AppEnvironmentTests: XCTestCase {
             sampleRate: 1.0,
             remoteConfigClient: nil
         )
-        let tag = await client.getTag(name: "app.environment")
-        XCTAssertEqual(tag, "testflight")
+        let environmentTag = await client.getTag(name: "app.environment")
+        XCTAssertEqual(environmentTag, "testflight")
+        let releaseTag = await client.getTag(name: "app.release")
+        XCTAssertEqual(releaseTag, "true")
         await client.stopFlushTimer()
+    }
+
+    func testDetectedReleaseBuildIsFalseOnTestHosts() {
+        // Test hosts are debug builds (and often simulators).
+        XCTAssertFalse(AppEnvironment.isReleaseBuild)
+    }
+
+    func testProvisioningEntitlementsParsing() {
+        let plist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>Name</key>
+            <string>Dev Profile</string>
+            <key>Entitlements</key>
+            <dict>
+                <key>get-task-allow</key>
+                <true/>
+            </dict>
+        </dict>
+        </plist>
+        """
+        // Emulate the CMS envelope: binary garbage around the XML plist.
+        var blob = Data([0x30, 0x82, 0xDE, 0xAD])
+        blob.append(Data(plist.utf8))
+        blob.append(Data([0xBE, 0xEF]))
+
+        let entitlements = AppEnvironment.provisioningEntitlements(in: blob)
+        XCTAssertEqual(entitlements?["get-task-allow"] as? Bool, true)
+
+        XCTAssertNil(AppEnvironment.provisioningEntitlements(in: Data([0x00, 0x01])))
     }
 
     func testEnvironmentTagDoesNotAffectSampling() async {

--- a/Tests/AmplitudeCoreTests/AppEnvironmentTests.swift
+++ b/Tests/AmplitudeCoreTests/AppEnvironmentTests.swift
@@ -1,0 +1,84 @@
+//
+//  AppEnvironmentTests.swift
+//  AmplitudeCore
+//
+//  Created by Jin Xu on 07/23/26.
+//
+
+import XCTest
+@_spi(Internal) @testable import AmplitudeCore
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+final class AppEnvironmentTests: XCTestCase {
+
+    override func tearDown() {
+        AppEnvironment.overrideForTesting = nil
+        super.tearDown()
+    }
+
+    func testTestOverrideTakesPrecedence() {
+        AppEnvironment.overrideForTesting = .testFlight
+        XCTAssertEqual(AppEnvironment.current, .testFlight)
+
+        AppEnvironment.overrideForTesting = nil
+        // Test hosts never run as App Store installs.
+        XCTAssertNotEqual(AppEnvironment.current, .appStore)
+    }
+
+    func testContainingAppBundleURLResolvesExtensionHost() {
+        // iOS layout
+        XCTAssertEqual(
+            AppEnvironment.containingAppBundleURL(
+                of: URL(fileURLWithPath: "/private/var/containers/Bundle/Application/ABC/MyApp.app/PlugIns/Widget.appex"))?.path,
+            "/private/var/containers/Bundle/Application/ABC/MyApp.app")
+        // macOS layout
+        XCTAssertEqual(
+            AppEnvironment.containingAppBundleURL(
+                of: URL(fileURLWithPath: "/Applications/MyApp.app/Contents/PlugIns/Share.appex"))?.path,
+            "/Applications/MyApp.app")
+    }
+
+    func testContainingAppBundleURLReturnsNilForNonExtensions() {
+        // Not an extension bundle.
+        XCTAssertNil(AppEnvironment.containingAppBundleURL(
+            of: URL(fileURLWithPath: "/Applications/MyApp.app")))
+        // Extension with no enclosing .app ancestor.
+        XCTAssertNil(AppEnvironment.containingAppBundleURL(
+            of: URL(fileURLWithPath: "/tmp/Orphan.appex")))
+    }
+
+    func testEnvironmentTagValues() {
+        XCTAssertEqual(AppEnvironment.appStore.rawValue, "appstore")
+        XCTAssertEqual(AppEnvironment.testFlight.rawValue, "testflight")
+        XCTAssertEqual(AppEnvironment.development.rawValue, "development")
+        XCTAssertEqual(AppEnvironment.simulator.rawValue, "simulator")
+    }
+
+    func testEnvironmentTagIsSetOnDiagnostics() async {
+        AppEnvironment.overrideForTesting = .testFlight
+        let client = DiagnosticsClient(
+            apiKey: "test-app-environment-key",
+            instanceName: "test-app-environment-\(UUID().uuidString)",
+            enabled: true,
+            sampleRate: 1.0,
+            remoteConfigClient: nil
+        )
+        let tag = await client.getTag(name: "app.environment")
+        XCTAssertEqual(tag, "testflight")
+        await client.stopFlushTimer()
+    }
+
+    func testEnvironmentTagDoesNotAffectSampling() async {
+        AppEnvironment.overrideForTesting = .simulator
+        let client = DiagnosticsClient(
+            apiKey: "test-app-environment-key",
+            instanceName: "test-app-environment-\(UUID().uuidString)",
+            enabled: true,
+            sampleRate: 1.0,
+            remoteConfigClient: nil
+        )
+        let shouldTrack = await client.shouldTrack
+        XCTAssertTrue(shouldTrack, "Tag-only phase: environment must not gate sampling")
+        await client.stopFlushTimer()
+    }
+}

--- a/Tests/AmplitudeCoreTests/DiagnosticsClientTests.swift
+++ b/Tests/AmplitudeCoreTests/DiagnosticsClientTests.swift
@@ -26,7 +26,15 @@ final class DiagnosticsClientTests: XCTestCase {
     override func setUp() async throws {
         TestDiagnosticsHandler.reset()
         CrashCatcher.reset()
+        // Pin the environment tag so uploaded payloads are deterministic
+        // regardless of the test host (simulator, macOS, device).
+        AppEnvironment.overrideForTesting = .appStore
         testInstanceName = "test-diagnostics-instance-\(UUID().uuidString)"
+    }
+
+    override func tearDown() {
+        AppEnvironment.overrideForTesting = nil
+        super.tearDown()
     }
 
     /// Helper to skip tests that require URLProtocol on watchOS (where it doesn't work)

--- a/Tests/AmplitudeCoreTests/DiagnosticsRemoteConfigTests.swift
+++ b/Tests/AmplitudeCoreTests/DiagnosticsRemoteConfigTests.swift
@@ -17,6 +17,14 @@ final class DiagnosticsRemoteConfigTests: XCTestCase {
         super.setUp()
         // Reset remote config storage before each test
         TestRemoteConfigStorage.shared.reset()
+        // Pin the environment tag so uploaded payloads are deterministic
+        // regardless of the test host (simulator, macOS, device).
+        AppEnvironment.overrideForTesting = .appStore
+    }
+
+    override func tearDown() {
+        AppEnvironment.overrideForTesting = nil
+        super.tearDown()
     }
 
     /// Helper to skip tests that require URLProtocol on watchOS (where it doesn't work)


### PR DESCRIPTION
### Summary

Diagnostics aggregates are currently polluted by non-production runs: simulator and development sessions routinely exercise stress scenarios whose outliers dominate max-type aggregates (e.g. `sessionReplay.event.size.packed.max`) and would skew calibration of the upcoming single-event size guard (SDKI-14).

This PR tags every diagnostics session with two dimensions:

- **`app.release: true | false`** — deterministic release-build flag; this is the intended trust boundary for guard-phase sampling. Detection never touches receipts: `DEBUG` compilation condition (source-integrated SDKs compile with the host app's configuration), simulator check, `get-task-allow` entitlement (macOS/Catalyst via SecTask; iOS family via the embedded provisioning profile's entitlements — store installs embed no profile, ad-hoc/enterprise profiles carry `false`).
- **`app.environment: appstore | testflight | developerid | development | simulator`** — best-effort distribution channel for observability; whether to keep it will be decided once field data is in.

The keys deliberately avoid the org-wide `environment` (deploy env) tag to prevent vocabulary collisions (that key is used by 489+ infra/backend metrics with production/staging semantics).

**Rollout is observability-first by design**: this release only tags (purely additive, no change to sampling or upload behavior). Once field data confirms detection reliability, a follow-up will gate sampling on `app.release:true`.

Channel detection details:

- **iOS family** (same technique as Firebase's `GULAppEnvironmentUtil`): simulator → compile-time check; embedded provisioning profile → `development`; receipt URL named `sandboxReceipt` (checked on both the process bundle and, for app extensions, the resolved containing-app bundle) → `testflight`; otherwise `appstore`.
- **macOS / Catalyst** (code-signature based): `get-task-allow` entitlement → `development`; receipt payload containing `ProductionSandbox` → `testflight` (Mac receipts keep the production filename); receipt present otherwise → `appstore`; `Developer ID Application` leaf certificate → `developerid` (direct distribution is production end-user traffic); otherwise `development` (deliberately conservative — see review threads).
- App extensions resolve the containing app's bundle before classifying — receipts and profiles live in the host app, not the `.appex`.

Also fixes a pre-existing race where an early `flush()` could upload a snapshot before the basic tags (device, version, and the new app.* tags) landed in storage.

Known limitations:

- `appStoreReceiptURL` (used only by the best-effort channel tag, not by `app.release`) is deprecated as of iOS 18 / macOS 15; no warning at our deployment targets.

Validation: full suite green on macOS (155) and iOS simulator (57); visionOS and Mac Catalyst builds verified.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No

<details>
<summary>AI Prompt</summary>

原始需求:"如果能准确过滤只保留 appstore 的数据的话,我倾向于只有 appstore 数据才能进入 sample。因为其他数据可能对 max 产生重大影响。这应该是一个 diagnostics 的基础范围的过滤。"

后续调整:"我想这一版先把它做成 tag,先不做成 guard。之后确认数据稳定后再改成 guard。" / "有些 mac app 是作者打包直接分发的……本质上他们应该被包含在收集范围。" / "反过来想,如果我信任所有 release app 的话,我们能做到准确的判断宿主 app 是不是 release build 吗?"(→ 新增确定性的 app.release tag,渠道 tag 保留观测,有数据后再定去留)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)